### PR TITLE
Fix manager clean query params

### DIFF
--- a/src/MercadoPago/Manager.php
+++ b/src/MercadoPago/Manager.php
@@ -72,7 +72,6 @@ class Manager
     public function execute($entity, $method = 'get', $options = [])
     {
 
-        $this->cleanQueryParams($entity);
         $configuration = $this->_getEntityConfiguration($entity);
 
         if ($method != 'get'){

--- a/tests/resources/PaymentTest.php
+++ b/tests/resources/PaymentTest.php
@@ -133,6 +133,21 @@ class PaymentTest extends TestCase
     }
     
     /**
+     * @depends testCreatePendingPayment
+     */
+    public function testPaymentsSearchNotFound(MercadoPago\Payment $payment_created_previously) {
+
+        $filters = array(
+            "external_reference" => 'invalid_reference'
+        );
+
+        $payments = MercadoPago\Payment::search($filters);
+
+        $this->assertEquals(count($payments), 0);
+
+    }
+
+    /**
      * @depends testCreatePendingPayment 
      */
     public function testCancelPayment(MercadoPago\Payment $payment_created_previously) {


### PR DESCRIPTION
En #166 se comenta que el metodo cleanQueryParams en Manager sobreescribe los parametros cargados por entity. El test testPaymentsSearch pasaba de largo porque cualquier external_reference que le pasabas igual te iba a devolver el mismo unico pago de la prueba. Ahi agregue un test testPaymentsSearchNotFound que el nombre no es muy agraciado, pero prueba un caso no contemplado.