### PR TITLE
Use semantic versioning constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,17 +21,17 @@
     }
   ],
   "require": {
-    "php": ">=5.5.0",
-    "doctrine/common": "~2.6",
-    "doctrine/annotations": "~1.4"
+    "php": "^5.5|^7.0",
+    "doctrine/common": "^2.6",
+    "doctrine/annotations": "^1.4"
   },
   "require-dev": {
     "phpunit/phpunit": "^5",
-    "symfony/yaml": "~2.5",
-    "phpmd/phpmd": "@stable",
-    "squizlabs/php_codesniffer": "2.3.*",
-    "sebastian/phpcpd": "*", 
-    "doctrine/orm": "~2.3",
+    "symfony/yaml": "^2.5",
+    "phpmd/phpmd": "^1.0|^2.0",
+    "squizlabs/php_codesniffer": "^2.3",
+    "sebastian/phpcpd": "^2.0|^3.0|^4.0",
+    "doctrine/orm": "^2.3",
     "vlucas/phpdotenv": "^2.5"
   },
   "autoload": {


### PR DESCRIPTION
Use semantic versioning constraints instead of unbound targets like "*".

PHP version was also narrowed from ">=5.5.0" to "^5.5|^7.0", so if a major version (like `8.0.0`) is released, we need to edit the constraint to explicitly allow that version after ensuring the library is fully compatible.