### PR TITLE
Autoload classes under "tests/" directory only from "autoload-dev"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "symfony/yaml": "~2.5",
     "phpmd/phpmd": "@stable",
     "squizlabs/php_codesniffer": "2.3.*",
-    "sebastian/phpcpd": "*", 
+    "sebastian/phpcpd": "*",
     "doctrine/orm": "~2.3",
     "vlucas/phpdotenv": "^2.5"
   },
@@ -38,10 +38,16 @@
     "psr-4": {
       "MercadoPago\\": [
         "src/MercadoPago/",
-        "tests/",
         "src/MercadoPago/Generic/",
         "src/MercadoPago/Entities/",
         "src/MercadoPago/Entities/Shared/"
+      ]
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "MercadoPago\\": [
+        "tests/"
       ]
     }
   }


### PR DESCRIPTION
Autoload classes under "tests/" directory only from "autoload-dev".

This prevents these classes to be loaded when the library is installed as requirement from a third party project.