### PR TITLE
Add "extra.branch-alias" config at `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "symfony/yaml": "~2.5",
     "phpmd/phpmd": "@stable",
     "squizlabs/php_codesniffer": "2.3.*",
-    "sebastian/phpcpd": "*", 
+    "sebastian/phpcpd": "*",
     "doctrine/orm": "~2.3",
     "vlucas/phpdotenv": "^2.5"
   },
@@ -43,6 +43,11 @@
         "src/MercadoPago/Entities/",
         "src/MercadoPago/Entities/Shared/"
       ]
+    }
+  },
+  "extra": {
+    "branch-alias": {
+      "dev-master": "1.x-dev"
     }
   }
 }


### PR DESCRIPTION
Add "extra.branch-alias" config in order to allow installing (unstable) development versions trusting semver.

With this change, `composer require "mercadopago/dx-php:^1.0@dev"` is allowed to be resolved to `master` as development branch.