### PR TITLE
Update `.travis.yml` in order to build with more PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,17 @@
 language: php
+dist: trusty
 php:
+  - "5.5"
   - "5.6"
   - "7.0"
   - "7.1"
   - "7.2"
+  - "7.3"
+  - "7.4snapshot"
 
 before_script:
   - composer self-update
   - composer install --no-interaction
 
 script:
-  - vendor/bin/phpunit 
+  - vendor/bin/phpunit


### PR DESCRIPTION
Update `.travis.yml` in order to build with PHP `7.3` and `7.4snapshot`.
Builds against `php:5.5` were also added since the constraint currently declared on the project's dependencies allows that version too:
https://github.com/mercadopago/dx-php/blob/55b69bcac9be15223349f53b3db0eafb3fd946aa/composer.json#L24