### PR TITLE
Update composer.json doctrine/common ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
   ],
   "require": {
     "php": ">=7.1.0",
-    "doctrine/common": "^2.6",
+    "doctrine/common": "^3.0",
     "doctrine/annotations": "^1.8"
   },
   "require-dev": {


### PR DESCRIPTION
Needed to make it compatible with Laravel Framework 7.23.2

Doctrine versions used by Laravel 7.23.2

doctrine/annotations               1.10.3   
doctrine/cache                     1.10.2    
doctrine/collections               1.6.7     
doctrine/common                    3.0.2     
doctrine/event-manager             1.1.1     
doctrine/inflector                 2.0.3    
doctrine/instantiator              1.3.1     
doctrine/lexer                     1.2.1    
doctrine/persistence               2.0.0     
doctrine/reflection                1.2.1