### PR TITLE
handle error 400 without cause in response

### DIFF
--- a/src/MercadoPago/Entity.php
+++ b/src/MercadoPago/Entity.php
@@ -275,6 +275,11 @@ abstract class Entity
             $message['error'],
             $message['status']
         );
+         
+        if (is_null($message['cause'])) {
+            $message['cause'] = ['code' => $message['status'], 'description' => $message['message']];
+        }
+        
         $recuperable_error->proccess_causes($message['cause']);
         $this->error = $recuperable_error;
     }


### PR DESCRIPTION
Se genera el siguiente error
```
ErrorException
Invalid argument supplied for foreach()
```

Cuando se recibe un error 400 en el response, el parámetro `cause` que llega  es `null`

Para recrearlo necesitan generar un error 400, en mi caso fue currency_id inválido
```
Error: invalid_items
Status: 400
Mensaje currency_id invalid 
```

