### PR TITLE
Updated doctrine version in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "phpmd/phpmd": "@stable",
     "squizlabs/php_codesniffer": "2.3.*",
     "sebastian/phpcpd": "*", 
-    "doctrine/orm": "~2.3",
+    "doctrine/orm": "^2.3",
     "vlucas/phpdotenv": "^2.5",
     "phpdocumentor/phpdocumentor": "^2.0"
   },


### PR DESCRIPTION
Version 2.3 of the doctrine ORM had conflicts with the latest Laravel framework dependencies. This PR only changes the doctrin/orm package version so dx-php supports some newer versions of the ORM.