### PR TITLE
Adicionar a propriedade advanced_payment_id e a refund_id que estavam…

### DIFF
--- a/src/MercadoPago/Entities/AdvancedPayments/Refund.php
+++ b/src/MercadoPago/Entities/AdvancedPayments/Refund.php
@@ -58,4 +58,18 @@ class Refund extends Entity {
      */
     protected $date_created;
 
+    /**
+     * advanced_payment_id
+     * @Attribute(serialize=false)
+     * @var int
+     */
+    protected $advanced_payment_id;
+
+    /**
+     * refund_id
+     * @Attribute(serialize=false)
+     * @var int
+     */
+    protected $refund_id;
+
 }


### PR DESCRIPTION
added the property advanced_payment_id and the refund_id that was missing in the class Refund.php, It was raise an error on call the method refund from the class AdvancedPayments.php in the SDK MercadoPago.

Adicionar a propriedade advanced_payment_id e a refund_id que estavam faltando na classe Refund.php, estava causando erro ao chamar o metodo refund da classe AdvancedPayments.php pela SDK do Mercado Pago.