### PR TITLE
Allow Symfony 5.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   },
   "require": {
     "php": ">=7.1.0",
-    "doctrine/common": "^2.6",
+    "doctrine/common": "^2.6 || ^3.0",
     "doctrine/annotations": "^1.8"
   },
   "require-dev": {
@@ -20,7 +20,7 @@
     "symfony/yaml": "~2.5",
     "phpmd/phpmd": "@stable",
     "squizlabs/php_codesniffer": "2.3.*",
-    "sebastian/phpcpd": "*", 
+    "sebastian/phpcpd": "*",
     "doctrine/orm": "~2.3",
     "vlucas/phpdotenv": "^2.5",
     "phpdocumentor/phpdocumentor": "^2.0"


### PR DESCRIPTION
The same as #280, but better 🙂 

This is blocking me from upgrading to Symfony 5.x, because `doctrine/persistence:^2` can't be installed