### PR TITLE
Added payment_method_id and card_id to Preapproval entity

### DIFF
--- a/src/MercadoPago/Entities/Preapproval.php
+++ b/src/MercadoPago/Entities/Preapproval.php
@@ -124,14 +124,14 @@ class Preapproval extends Entity
    */
   protected $preapproval_plan_id;
   
-    /**
+  /**
    * payment_method_id
    * @Attribute()
    * @var string
    */
   protected $payment_method_id;
 
-    /**
+  /**
    * card_id
    * @Attribute()
    * @var string

--- a/src/MercadoPago/Entities/Preapproval.php
+++ b/src/MercadoPago/Entities/Preapproval.php
@@ -124,4 +124,17 @@ class Preapproval extends Entity
    */
   protected $preapproval_plan_id;
   
+    /**
+   * payment_method_id
+   * @Attribute()
+   * @var string
+   */
+  protected $payment_method_id;
+
+    /**
+   * card_id
+   * @Attribute()
+   * @var string
+   */
+  protected $card_id;
 }


### PR DESCRIPTION
The preapproval entity struct didn't have payment_method_id and card_id fields, what was resulting in unwanted warnings. 
To correct this behavior, both fields were added. 