### PR TITLE
Added payment_method_id and card_id to Preapproval entity

### DIFF
--- a/src/MercadoPago/Entities/Preapproval.php
+++ b/src/MercadoPago/Entities/Preapproval.php
@@ -90,6 +90,16 @@ class Preapproval extends Entity
    * @Attribute()
    */
   protected $preapproval_plan_id;
+
+   /**
+   * @Attribute()
+   */
+  protected $payment_method_id;
+
+   /**
+   * @Attribute()
+   */
+  protected $card_id;
   
 }
 

--- a/src/MercadoPago/Entities/Preapproval.php
+++ b/src/MercadoPago/Entities/Preapproval.php
@@ -91,12 +91,12 @@ class Preapproval extends Entity
    */
   protected $preapproval_plan_id;
 
-   /**
+  /**
    * @Attribute()
    */
   protected $payment_method_id;
 
-   /**
+  /**
    * @Attribute()
    */
   protected $card_id;


### PR DESCRIPTION
The preapproval entity struct didn't have payment_method_id and card_id fields, what was resulting in unwanted warnings. 
To correct this behavior, both fields were added. 