### PR TITLE
Verify if response error has required values

### DIFF
--- a/src/MercadoPago/Entity.php
+++ b/src/MercadoPago/Entity.php
@@ -263,6 +263,10 @@ abstract class Entity
     }
 
     function process_error_body($message){
+        if( !isset($message['error']) ) $message['error'] = '';
+        if( !isset($message['message']) ) $message['message'] = '';
+        if( !isset($message['status']) ) $message['status'] = '';
+        
         $recuperable_error = new RecuperableError(
             $message['message'],
             $message['error'],


### PR DESCRIPTION
If you get an error from response, the function process_error_body will be called.

Sometimes the required params from the response body will not met the required in the RecuperableError class.

The simple solution is to first verify if the required params exist in response body.