### PR TITLE
update squizlabs/php_codesniffer version to 2.8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "phpunit/phpunit": "^5",
     "symfony/yaml": "~2.5",
     "phpmd/phpmd": "@stable",
-    "squizlabs/php_codesniffer": "2.3.*",
+    "squizlabs/php_codesniffer": "2.8.1",
     "sebastian/phpcpd": "*",
     "doctrine/orm": "~2.3",
     "vlucas/phpdotenv": "^2.5",


### PR DESCRIPTION
Update squizlabs/php_codesniffer version to 2.8.1 due to vulnerability.