### PR TITLE
Adds validation to is_file

### DIFF
--- a/src/MercadoPago/Config.php
+++ b/src/MercadoPago/Config.php
@@ -54,14 +54,14 @@ class Config
     /**
      * Config constructor.
      *
-     * @param null $path
+     * @param string|null $path
      * @param null $restClient
      */
     public function __construct($path = null, $restClient = null)
     {
         $this->data = [];
         $this->_restclient = $restClient;
-        if (is_file($path)) {
+        if (is_file($path ?? '')) {
             $info = pathinfo($path);
             $parts = explode('.', $info['basename']);
             $extension = array_pop($parts);


### PR DESCRIPTION
This PR resolves the following warning:
`Deprecated: is_file(): Passing null to parameter #1 ($filename) of type string is deprecated in /project/vendor/mercadopago/dx-php/src/MercadoPago/Config.php on line 64`