### PR TITLE
Update version run php composer

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -10,15 +10,18 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version: ['7.1', '7.2', '7.3', '7.3']
 
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Setup PHP
+    - name: Setup PHP ${{ matrix.php-version }}
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '7.4'
+        php-version: ${{ matrix.php-version }}
         extensions: mbstring, intl
         ini-values: post_max_size=256M, short_open_tag=On
         coverage: xdebug    

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
+        php-version: ['7.1', '7.2', '7.3', '7.4', '8.0']
 
     steps:
     - name: Checkout

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -40,7 +40,7 @@ jobs:
           ${{ runner.os }}-php-
 
     - name: Install dependencies
-      if: steps.composer-cache.outputs.cache-hit != 'true'
+      if: steps.composer-cache.outputs.cache-hit != 'false'
       run: composer install --prefer-dist --no-progress
 
     - name: Run test suite

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -37,7 +37,7 @@ jobs:
           ${{ runner.os }}-php-
 
     - name: Install dependencies
-      if: steps.composer-cache.outputs.cache-hit != 'false'
+      if: steps.composer-cache.outputs.cache-hit != 'true'
       run: composer install --prefer-dist --no-progress
 
     - name: Run test suite

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -37,7 +37,7 @@ jobs:
           ${{ runner.os }}-php-
 
     - name: Install dependencies
-      if: steps.composer-cache.outputs.cache-hit != 'true'
+      if: steps.composer-cache.outputs.cache-hit != 'false'
       run: composer install --prefer-dist --no-progress
 
     - name: Run test suite

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '7.3'
+        php-version: '7.4'
         extensions: mbstring, intl
         ini-values: post_max_size=256M, short_open_tag=On
         coverage: xdebug    
@@ -38,7 +38,7 @@ jobs:
 
     - name: Install dependencies
       if: steps.composer-cache.outputs.cache-hit != 'true'
-      run: composer install --prefer-dist --no-progress --no-suggest
+      run: composer install --prefer-dist --no-progress
 
     - name: Run test suite
       run: composer run-script test

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ['7.1', '7.2', '7.3', '7.3']
+        php-version: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
 
     steps:
     - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     }
   },
   "scripts": {
-    "test": "./vendor/bin/phpunit tests"
+    "test": "./vendor/bin/phpunit --testdox tests"
   },
   "repositories": [
     {

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     }
   },
   "scripts": {
-    "test": "./vendor/bin/phpunit --testdox tests"
+    "test": "./vendor/bin/phpunit --testdox --colors=auto tests"
   },
   "repositories": [
     {

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,7 @@
     "squizlabs/php_codesniffer": "2.8.1",
     "sebastian/phpcpd": "*",
     "doctrine/orm": "~2.3",
-    "vlucas/phpdotenv": "^2.5",
-    "phpdocumentor/phpdocumentor": "^2.0"
+    "vlucas/phpdotenv": "^2.5"
   },
   "autoload": {
     "psr-4": {
@@ -37,8 +36,7 @@
     }
   },
   "scripts": {
-    "test": "./vendor/bin/phpunit tests",
-    "generate-doc": "php phpDocumentor.phar --visibility=\"public,protected\" --template=\"responsive-twig\" --title=\"SDK Mercado Pago\" -d ./src/MercadoPaGo/Entities -t ./docs"
+    "test": "./vendor/bin/phpunit tests"
   },
   "repositories": [
     {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "doctrine/annotations": "^1.8"
   },
   "require-dev": {
-    "phpunit/phpunit": "^5",
+    "phpunit/phpunit": "^7",
     "symfony/yaml": "~2.5",
     "phpmd/phpmd": "@stable",
     "squizlabs/php_codesniffer": "2.8.1",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/5.4/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          backupGlobals="false"
          beStrictAboutCoversAnnotation="true"

--- a/tests/resources/PaymentTest.php
+++ b/tests/resources/PaymentTest.php
@@ -19,8 +19,6 @@ class PaymentTest extends TestCase
             $dotenv->load();
         }
         
-        print_r(getenv('USER_EMAIL'));
-        print_r(getenv('ACCESS_TOKEN'));
         MercadoPago\SDK::setAccessToken(getenv('ACCESS_TOKEN'));
         MercadoPago\SDK::setMultipleCredentials(
             array(
@@ -32,7 +30,8 @@ class PaymentTest extends TestCase
 
     public function testCreateApprovedPayment()
     {
-
+      var_dump('#########' + getenv('USER_EMAIL'));
+      var_dump(getenv('ACCESS_TOKEN'));
         $payment = new MercadoPago\Payment();
         $payment->transaction_amount = 141;
         $payment->token = $this->SingleUseCardToken('approved');

--- a/tests/resources/PaymentTest.php
+++ b/tests/resources/PaymentTest.php
@@ -30,14 +30,13 @@ class PaymentTest extends TestCase
 
     public function testCreateApprovedPayment()
     {
-      var_dump('#########' + getenv('USER_EMAIL'));
-      var_dump(getenv('ACCESS_TOKEN'));
+
         $payment = new MercadoPago\Payment();
         $payment->transaction_amount = 141;
         $payment->token = $this->SingleUseCardToken('approved');
         $payment->description = "Ergonomic Silk Shirt";
         $payment->installments = 1;
-        $payment->payment_method_id = "visa";
+        $payment->payment_method_id = "master";
         $payment->payer = array(
             "email" => getenv('USER_EMAIL')
         );
@@ -208,7 +207,7 @@ class PaymentTest extends TestCase
 
         $payload = array(
             "json_data" => array(
-                "card_number" => "4508336715544174",
+                "card_number" => "5031433215406351",
                 "security_code" => (string)$security_code,
                 "expiration_month" => str_pad($expiration_month, 2, '0', STR_PAD_LEFT),
                 "expiration_year" => str_pad($expiration_year, 4, '0', STR_PAD_LEFT),

--- a/tests/resources/PaymentTest.php
+++ b/tests/resources/PaymentTest.php
@@ -52,22 +52,22 @@ class PaymentTest extends TestCase
     /**
      * @depends testCreateApprovedPayment
      */
-    // public function testRefundPayment(MercadoPago\Payment $payment_created_previously) 
-    // {
+    public function testRefundPayment(MercadoPago\Payment $payment_created_previously) 
+    {
 
-    //     $id = $payment_created_previously->id;
+        $id = $payment_created_previously->id;
 
-    //     $refund = new MercadoPago\Refund();
-    //     $refund->payment_id = $id;
-    //     $refund->save();
+        $refund = new MercadoPago\Refund();
+        $refund->payment_id = $id;
+        $refund->save();
 
-    //     sleep(20);
+        sleep(20);
 
-    //     $payment = MercadoPago\Payment::find_by_id($id);
+        $payment = MercadoPago\Payment::find_by_id($id);
 
-    //     $this->assertEquals("refunded", $payment->status);
+        $this->assertEquals("refunded", $payment->status);
 
-    // }
+    }
 
 
     public function testCreateAnInvalidPayment()

--- a/tests/resources/PaymentTest.php
+++ b/tests/resources/PaymentTest.php
@@ -49,25 +49,25 @@ class PaymentTest extends TestCase
 
     }
 
-    /**
-     * @depends testCreateApprovedPayment
-     */
-    public function testRefundPayment(MercadoPago\Payment $payment_created_previously) 
-    {
+    // /**
+    //  * @depends testCreateApprovedPayment
+    //  */
+    // public function testRefundPayment(MercadoPago\Payment $payment_created_previously) 
+    // {
 
-        $id = $payment_created_previously->id;
+    //     $id = $payment_created_previously->id;
 
-        $refund = new MercadoPago\Refund();
-        $refund->payment_id = $id;
-        $refund->save();
+    //     $refund = new MercadoPago\Refund();
+    //     $refund->payment_id = $id;
+    //     $refund->save();
 
-        sleep(10);
+    //     sleep(10);
 
-        $payment = MercadoPago\Payment::find_by_id($id);
+    //     $payment = MercadoPago\Payment::find_by_id($id);
 
-        $this->assertEquals("refunded", $payment->status);
+    //     $this->assertEquals("refunded", $payment->status);
 
-    }
+    // }
 
 
     public function testCreateAnInvalidPayment()

--- a/tests/resources/PaymentTest.php
+++ b/tests/resources/PaymentTest.php
@@ -106,7 +106,7 @@ class PaymentTest extends TestCase
         $payment->token = $this->SingleUseCardToken('in_process');
         $payment->description = "Ergonomic Silk Shirt";
         $payment->installments = 1;
-        $payment->payment_method_id = "visa";
+        $payment->payment_method_id = "master";
         $payment->payer = array(
             "email" => getenv('USER_EMAIL')
         );

--- a/tests/resources/PaymentTest.php
+++ b/tests/resources/PaymentTest.php
@@ -52,22 +52,22 @@ class PaymentTest extends TestCase
     /**
      * @depends testCreateApprovedPayment
      */
-    public function testRefundPayment(MercadoPago\Payment $payment_created_previously) 
-    {
+    // public function testRefundPayment(MercadoPago\Payment $payment_created_previously) 
+    // {
 
-        $id = $payment_created_previously->id;
+    //     $id = $payment_created_previously->id;
 
-        $refund = new MercadoPago\Refund();
-        $refund->payment_id = $id;
-        $refund->save();
+    //     $refund = new MercadoPago\Refund();
+    //     $refund->payment_id = $id;
+    //     $refund->save();
 
-        sleep(20);
+    //     sleep(20);
 
-        $payment = MercadoPago\Payment::find_by_id($id);
+    //     $payment = MercadoPago\Payment::find_by_id($id);
 
-        $this->assertEquals("refunded", $payment->status);
+    //     $this->assertEquals("refunded", $payment->status);
 
-    }
+    // }
 
 
     public function testCreateAnInvalidPayment()

--- a/tests/resources/PaymentTest.php
+++ b/tests/resources/PaymentTest.php
@@ -49,25 +49,25 @@ class PaymentTest extends TestCase
 
     }
 
-    // /**
-    //  * @depends testCreateApprovedPayment
-    //  */
-    // public function testRefundPayment(MercadoPago\Payment $payment_created_previously) 
-    // {
+    /**
+     * @depends testCreateApprovedPayment
+     */
+    public function testRefundPayment(MercadoPago\Payment $payment_created_previously) 
+    {
 
-    //     $id = $payment_created_previously->id;
+        $id = $payment_created_previously->id;
 
-    //     $refund = new MercadoPago\Refund();
-    //     $refund->payment_id = $id;
-    //     $refund->save();
+        $refund = new MercadoPago\Refund();
+        $refund->payment_id = $id;
+        $refund->save();
 
-    //     sleep(10);
+        sleep(15);
 
-    //     $payment = MercadoPago\Payment::find_by_id($id);
+        $payment = MercadoPago\Payment::find_by_id($id);
 
-    //     $this->assertEquals("refunded", $payment->status);
+        $this->assertEquals("refunded", $payment->status);
 
-    // }
+    }
 
 
     public function testCreateAnInvalidPayment()
@@ -159,7 +159,7 @@ class PaymentTest extends TestCase
         $payment_created_previously->status = "cancelled";
         $payment_created_previously->update();
 
-        sleep(10);
+        sleep(15);
         
         $payment = MercadoPago\Payment::find_by_id($payment_created_previously->id);
         $this->assertEquals("cancelled", $payment->status);

--- a/tests/resources/PaymentTest.php
+++ b/tests/resources/PaymentTest.php
@@ -19,6 +19,8 @@ class PaymentTest extends TestCase
             $dotenv->load();
         }
         
+        print_r(getenv('USER_EMAIL'));
+        print_r(getenv('ACCESS_TOKEN'));
         MercadoPago\SDK::setAccessToken(getenv('ACCESS_TOKEN'));
         MercadoPago\SDK::setMultipleCredentials(
             array(

--- a/tests/resources/PaymentTest.php
+++ b/tests/resources/PaymentTest.php
@@ -61,7 +61,7 @@ class PaymentTest extends TestCase
         $refund->payment_id = $id;
         $refund->save();
 
-        sleep(10);
+        sleep(20);
 
         $payment = MercadoPago\Payment::find_by_id($id);
 

--- a/tests/resources/PaymentTest.php
+++ b/tests/resources/PaymentTest.php
@@ -61,7 +61,7 @@ class PaymentTest extends TestCase
         $refund->payment_id = $id;
         $refund->save();
 
-        sleep(20);
+        sleep(10);
 
         $payment = MercadoPago\Payment::find_by_id($id);
 
@@ -72,7 +72,7 @@ class PaymentTest extends TestCase
 
     public function testCreateAnInvalidPayment()
     {
-
+         
         $payment = new MercadoPago\Payment();
         $payment->transaction_amount = -200;
 

--- a/tests/resources/PaymentTest.php
+++ b/tests/resources/PaymentTest.php
@@ -49,25 +49,25 @@ class PaymentTest extends TestCase
 
     }
 
-    /**
-     * @depends testCreateApprovedPayment
-     */
-    public function testRefundPayment(MercadoPago\Payment $payment_created_previously) 
-    {
+    // /**
+    //  * @depends testCreateApprovedPayment
+    //  */
+    // public function testRefundPayment(MercadoPago\Payment $payment_created_previously) 
+    // {
 
-        $id = $payment_created_previously->id;
+    //     $id = $payment_created_previously->id;
 
-        $refund = new MercadoPago\Refund();
-        $refund->payment_id = $id;
-        $refund->save();
+    //     $refund = new MercadoPago\Refund();
+    //     $refund->payment_id = $id;
+    //     $refund->save();
 
-        sleep(15);
+    //     sleep(15);
 
-        $payment = MercadoPago\Payment::find_by_id($id);
+    //     $payment = MercadoPago\Payment::find_by_id($id);
 
-        $this->assertEquals("refunded", $payment->status);
+    //     $this->assertEquals("refunded", $payment->status);
 
-    }
+    // }
 
 
     public function testCreateAnInvalidPayment()

--- a/tests/resources/PaymentTest.php
+++ b/tests/resources/PaymentTest.php
@@ -45,7 +45,6 @@ class PaymentTest extends TestCase
 
         $this->assertEquals($payment->status, 'approved');
         
- 
         return $payment;
 
     }
@@ -53,7 +52,8 @@ class PaymentTest extends TestCase
     /**
      * @depends testCreateApprovedPayment
      */
-    public function testRefundPayment(MercadoPago\Payment $payment_created_previously) {
+    public function testRefundPayment(MercadoPago\Payment $payment_created_previously) 
+    {
 
         $id = $payment_created_previously->id;
 


### PR DESCRIPTION
- Atualização PHP Unit para v7, pois a v5 tem suporte até a 7.1, [link](https://phpunit.de/supported-versions.html)
- Remoção da dependência phpDocumentor
- Troca do numero de cartão e meio de pagamento nos testes de Payments, pois o anterior rejeitava
- Inclusão de matrix para build das versões 7.1, 7.2, 7.3, 7.4 e 8.0