### PR TITLE
Add money_release_days, money_release_status fields to Payment model

### DIFF
--- a/src/MercadoPago/Entities/Shared/Payment.php
+++ b/src/MercadoPago/Entities/Shared/Payment.php
@@ -185,11 +185,25 @@ class Payment extends Entity
     protected $money_release_date;
 
     /**
+     * money_release_days
+     * @var int
+     * @Attribute()
+     */
+    protected $money_release_days;
+
+    /**
      * money_release_schema
      * @var string
      * @Attribute()
      */
     protected $money_release_schema;
+    
+    /**
+     * money_release_status
+     * @var string
+     * @Attribute()
+     */
+    protected $money_release_status;
 
     /**
      * currency_id


### PR DESCRIPTION
Some users have reported having issues with `$payment->$refund` response payload due to money_release_status not being mapped:
`Undefined index: money_release_status in /var/www/html/MedPay/v1/Api/vendor/mercadopago/dx-php/src/MercadoPago/Manager.php:369`.

`money_release_days` was included to avoid similar issues with that field.