### PR TITLE
PHP 8.2 Support

### DIFF
--- a/src/MercadoPago/Entities/OAuth.php
+++ b/src/MercadoPago/Entities/OAuth.php
@@ -106,7 +106,7 @@ class OAuth extends Entity
      */
     public function getAuthorizationURL($app_id, $redirect_uri){
         $county_id = strtolower(SDK::getCountryId());
-        return "https://auth.mercadopago.com.${county_id}/authorization?client_id=${app_id}&response_type=code&platform_id=mp&redirect_uri=${redirect_uri}";
+        return "https://auth.mercadopago.com.{$county_id}/authorization?client_id={$app_id}&response_type=code&platform_id=mp&redirect_uri={$redirect_uri}";
     }
 
 

--- a/src/MercadoPago/Entity.php
+++ b/src/MercadoPago/Entity.php
@@ -7,6 +7,7 @@ use Exception;
  *
  * @package MercadoPago
  */
+#[AllowDynamicProperties]
 abstract class Entity
 {
     /**

--- a/src/MercadoPago/Entity.php
+++ b/src/MercadoPago/Entity.php
@@ -7,7 +7,7 @@ use Exception;
  *
  * @package MercadoPago
  */
-#[AllowDynamicProperties]
+#[\AllowDynamicProperties]
 abstract class Entity
 {
     /**


### PR DESCRIPTION
Fix: Deprecated ${} string interpolation
Add: [#[\AllowDynamicProperties]](https://www.php.net/manual/en/class.allow-dynamic-properties.php)