### PR TITLE
Update Manager.php for PHP 8.1 Deprecated Passing null

### DIFF
--- a/src/MercadoPago/Manager.php
+++ b/src/MercadoPago/Manager.php
@@ -152,7 +152,7 @@ class Manager
             } elseif (!empty($entity->$key)) {
                 $url = str_replace($match, $entity->$key, $url);
             } else {
-                $url = str_replace($match, $entity->{$key}, $url);
+                $url = str_replace($match, $entity->{$key} ?? '', $url);
             }
         }
         $this->_entityConfiguration[$className]->url = $url;


### PR DESCRIPTION
This line throw an warning when passing null. Generic solution to fix it ( ?? '')