### PR TITLE
Improve autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,10 +6,12 @@
     "homepage": "https://github.com/mercadopago/sdk-php",
     "autoload": {
         "psr-4": {
-            "MercadoPago\\": [
-                "src/MercadoPago",
-                "tests/MercadoPago"
-            ]
+            "MercadoPago\\": "src/MercadoPago"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "MercadoPago\\Tests\\": "tests/MercadoPago/"
         }
     },
     "require": {

--- a/composer.lock
+++ b/composer.lock
@@ -227,16 +227,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.25.1",
+            "version": "v3.26.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "8e21d69801de6b5ecb0dbe0bcdf967b335b1260b"
+                "reference": "d023ba6684055f6ea1da1352d8a02baca0426983"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/8e21d69801de6b5ecb0dbe0bcdf967b335b1260b",
-                "reference": "8e21d69801de6b5ecb0dbe0bcdf967b335b1260b",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/d023ba6684055f6ea1da1352d8a02baca0426983",
+                "reference": "d023ba6684055f6ea1da1352d8a02baca0426983",
                 "shasum": ""
             },
             "require": {
@@ -310,7 +310,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.25.1"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.26.1"
             },
             "funding": [
                 {
@@ -318,7 +318,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-09-04T01:22:52+00:00"
+            "time": "2023-09-08T19:09:07+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -869,16 +869,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.3.2",
+            "version": "10.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "0dafb1175c366dd274eaa9a625e914451506bcd1"
+                "reference": "241ed4dd0db1c096984e62d414c4e1ac8d5dbff4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0dafb1175c366dd274eaa9a625e914451506bcd1",
-                "reference": "0dafb1175c366dd274eaa9a625e914451506bcd1",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/241ed4dd0db1c096984e62d414c4e1ac8d5dbff4",
+                "reference": "241ed4dd0db1c096984e62d414c4e1ac8d5dbff4",
                 "shasum": ""
             },
             "require": {
@@ -950,7 +950,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.3.2"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.3.3"
             },
             "funding": [
                 {
@@ -966,7 +966,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-15T05:34:23+00:00"
+            "time": "2023-09-05T04:34:51+00:00"
         },
         {
             "name": "psr/container",
@@ -1556,16 +1556,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "5.0.0",
+            "version": "5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "f3ec4bf931c0b31e5b413f5b4fc970a7d03338c0"
+                "reference": "32ff03d078fed1279c4ec9a407d08c5e9febb480"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/f3ec4bf931c0b31e5b413f5b4fc970a7d03338c0",
-                "reference": "f3ec4bf931c0b31e5b413f5b4fc970a7d03338c0",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/32ff03d078fed1279c4ec9a407d08c5e9febb480",
+                "reference": "32ff03d078fed1279c4ec9a407d08c5e9febb480",
                 "shasum": ""
             },
             "require": {
@@ -1621,7 +1621,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/5.0.0"
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/5.0.1"
             },
             "funding": [
                 {
@@ -1629,7 +1630,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:06:49+00:00"
+            "time": "2023-09-08T04:46:58+00:00"
         },
         {
             "name": "sebastian/global-state",

--- a/tests/MercadoPago/Client/Base/BaseClient.php
+++ b/tests/MercadoPago/Client/Base/BaseClient.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace MercadoPago\Client\Base;
+namespace MercadoPago\Tests\Client\Base;
 
 use PHPUnit\Framework\TestCase;
 

--- a/tests/MercadoPago/Client/CardToken/CardTokenClientITTest.php
+++ b/tests/MercadoPago/Client/CardToken/CardTokenClientITTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace MercadoPago\Client\CardToken;
+namespace MercadoPago\Tests\Client\CardToken;
 
+use MercadoPago\Client\CardToken\CardTokenClient;
 use MercadoPago\Core\MPRequestOptions;
 use MercadoPago\Exceptions\MPApiException;
 use MercadoPago\MercadoPagoConfig;

--- a/tests/MercadoPago/Client/CardToken/CardTokenClientUnitTest.php
+++ b/tests/MercadoPago/Client/CardToken/CardTokenClientUnitTest.php
@@ -1,15 +1,16 @@
 <?php
 
-namespace MercadoPago\Client\CardToken;
+namespace MercadoPago\Tests\Client\CardToken;
 
+use MercadoPago\Client\CardToken\CardTokenClient;
 use MercadoPago\MercadoPagoConfig;
 use MercadoPago\Net\MPDefaultHttpClient;
-use PHPUnit\Framework\TestCase;
+use MercadoPago\Tests\Client\Base\BaseClient;
 
 /**
  * CardTokenClient unit tests.
  */
-final class CardTokenClientUnitTest extends TestCase
+final class CardTokenClientUnitTest extends BaseClient
 {
     public function testCreateSuccess(): void
     {
@@ -45,16 +46,6 @@ final class CardTokenClientUnitTest extends TestCase
         $this->assertEquals($id, $card_token->id);
     }
 
-    private function mockHttpRequest(string $file_path, int $status_code): \PHPUnit\Framework\MockObject\MockObject|\MercadoPago\Net\HttpRequest
-    {
-        /** @var \PHPUnit\Framework\MockObject\MockObject|\MercadoPago\Net\HttpRequest $mock_http_request */
-        $mock_http_request = $this->getMockBuilder(\MercadoPago\Net\HttpRequest::class)->getMock();
-
-        $response_json = file_get_contents(__DIR__ . $file_path);
-        $mock_http_request->method('execute')->willReturn($response_json);
-        $mock_http_request->method('getInfo')->willReturn($status_code);
-        return $mock_http_request;
-    }
     private function createRequest(): array
     {
         $request = [

--- a/tests/MercadoPago/Client/Customer/CustomerCardClientITTest.php
+++ b/tests/MercadoPago/Client/Customer/CustomerCardClientITTest.php
@@ -1,12 +1,13 @@
 <?php
 
-namespace MercadoPago\Client\Customer;
+namespace MercadoPago\Tests\Client\Customer;
 
 use MercadoPago\Core\MPRequestOptions;
 use MercadoPago\Exceptions\MPApiException;
 use MercadoPago\MercadoPagoConfig;
-use MercadoPago\Net\MPSearchRequest;
 use MercadoPago\Client\CardToken\CardTokenClient;
+use MercadoPago\Client\Customer\CustomerCardClient;
+use MercadoPago\Client\Customer\CustomerClient;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -177,14 +178,6 @@ final class CustomerCardClientITTest extends TestCase
     {
         $request = [
             "email" => $email
-        ];
-        return $request;
-    }
-
-    private function updateRequest(string $description_customer): array
-    {
-        $request = [
-            "description" => $description_customer
         ];
         return $request;
     }

--- a/tests/MercadoPago/Client/Customer/CustomerCardClientUnitTest.php
+++ b/tests/MercadoPago/Client/Customer/CustomerCardClientUnitTest.php
@@ -1,10 +1,11 @@
 <?php
 
-namespace MercadoPago\Client\Customer;
+namespace MercadoPago\Tests\Client\Customer;
 
+use MercadoPago\Client\Customer\CustomerCardClient;
 use MercadoPago\MercadoPagoConfig;
 use MercadoPago\Net\MPDefaultHttpClient;
-use MercadoPago\Client\Base\BaseClient;
+use MercadoPago\Tests\Client\Base\BaseClient;
 
 /**
  * Customer Card Client unit tests.

--- a/tests/MercadoPago/Client/Customer/CustomerClientITTest.php
+++ b/tests/MercadoPago/Client/Customer/CustomerClientITTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace MercadoPago\Client\Customer;
+namespace MercadoPago\Tests\Client\Customer;
 
+use MercadoPago\Client\Customer\CustomerClient;
 use MercadoPago\Core\MPRequestOptions;
 use MercadoPago\Exceptions\MPApiException;
 use MercadoPago\MercadoPagoConfig;

--- a/tests/MercadoPago/Client/Customer/CustomerClientUnitTest.php
+++ b/tests/MercadoPago/Client/Customer/CustomerClientUnitTest.php
@@ -1,10 +1,11 @@
 <?php
 
-namespace MercadoPago\Client\Customer;
+namespace MercadoPago\Tests\Client\Customer;
 
+use MercadoPago\Client\Customer\CustomerClient;
 use MercadoPago\MercadoPagoConfig;
 use MercadoPago\Net\MPDefaultHttpClient;
-use MercadoPago\Client\Base\BaseClient;
+use MercadoPago\Tests\Client\Base\BaseClient;
 
 /**
  * Customer Client unit tests.

--- a/tests/MercadoPago/Client/IdentificationType/IdentificationTypeClientITTest.php
+++ b/tests/MercadoPago/Client/IdentificationType/IdentificationTypeClientITTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace MercadoPago\Client\Customer;
+namespace MercadoPago\Tests\Client\Customer;
 
 use MercadoPago\Core\MPRequestOptions;
 use MercadoPago\Exceptions\MPApiException;

--- a/tests/MercadoPago/Client/IdentificationType/IdentificationTypeClientUnitTest.php
+++ b/tests/MercadoPago/Client/IdentificationType/IdentificationTypeClientUnitTest.php
@@ -1,10 +1,11 @@
 <?php
 
-namespace MercadoPago\Client\IdentificationType;
+namespace MercadoPago\Tests\Client\IdentificationType;
 
+use MercadoPago\Client\IdentificationType\IdentificationTypeClient;
 use MercadoPago\MercadoPagoConfig;
 use MercadoPago\Net\MPDefaultHttpClient;
-use MercadoPago\Client\Base\BaseClient;
+use MercadoPago\Tests\Client\Base\BaseClient;
 
 /**
  * Identification Type Client unit tests.

--- a/tests/MercadoPago/Client/Invoice/InvoiceClientUnitTest.php
+++ b/tests/MercadoPago/Client/Invoice/InvoiceClientUnitTest.php
@@ -1,10 +1,11 @@
 <?php
 
-namespace MercadoPago\Client\Invoice;
+namespace MercadoPago\Tests\Client\Invoice;
 
+use MercadoPago\Client\Invoice\InvoiceClient;
 use MercadoPago\MercadoPagoConfig;
 use MercadoPago\Net\MPDefaultHttpClient;
-use MercadoPago\Client\Base\BaseClient;
+use MercadoPago\Tests\Client\Base\BaseClient;
 
 /**
  * InvoiceClient unit tests.

--- a/tests/MercadoPago/Client/Payment/PaymentClientITTest.php
+++ b/tests/MercadoPago/Client/Payment/PaymentClientITTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace MercadoPago\Client\Payment;
+namespace MercadoPago\Tests\Client\Payment;
 
+use MercadoPago\Client\Payment\PaymentClient;
 use MercadoPago\Core\MPRequestOptions;
 use MercadoPago\Exceptions\MPApiException;
 use MercadoPago\MercadoPagoConfig;

--- a/tests/MercadoPago/Client/Payment/PaymentClientUnitTest.php
+++ b/tests/MercadoPago/Client/Payment/PaymentClientUnitTest.php
@@ -1,10 +1,11 @@
 <?php
 
-namespace MercadoPago\Client\Payment;
+namespace MercadoPago\Tests\Client\Payment;
 
+use MercadoPago\Client\Payment\PaymentClient;
 use MercadoPago\MercadoPagoConfig;
 use MercadoPago\Net\MPDefaultHttpClient;
-use MercadoPago\Client\Base\BaseClient;
+use MercadoPago\Tests\Client\Base\BaseClient;
 
 /**
  * Payment Client unit tests.

--- a/tests/MercadoPago/Client/Payment/PaymentRefundClientITTest.php
+++ b/tests/MercadoPago/Client/Payment/PaymentRefundClientITTest.php
@@ -1,11 +1,13 @@
 <?php
 
-namespace MercadoPago\Client\Payment;
+namespace MercadoPago\Tests\Client\Payment;
 
 use MercadoPago\Core\MPRequestOptions;
 use MercadoPago\Exceptions\MPApiException;
 use MercadoPago\MercadoPagoConfig;
 use MercadoPago\Client\CardToken\CardTokenClient;
+use MercadoPago\Client\Payment\PaymentClient;
+use MercadoPago\Client\Payment\PaymentRefundClient;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/MercadoPago/Client/Payment/PaymentRefundClientUnitTest.php
+++ b/tests/MercadoPago/Client/Payment/PaymentRefundClientUnitTest.php
@@ -1,10 +1,11 @@
 <?php
 
-namespace MercadoPago\Client\Payment;
+namespace MercadoPago\Tests\Client\Payment;
 
+use MercadoPago\Client\Payment\PaymentRefundClient;
 use MercadoPago\MercadoPagoConfig;
 use MercadoPago\Net\MPDefaultHttpClient;
-use MercadoPago\Client\Base\BaseClient;
+use MercadoPago\Tests\Client\Base\BaseClient;
 
 /**
  * Payment Refund Client unit tests.

--- a/tests/MercadoPago/Client/PaymentMethod/PaymentMethodClientITTest.php
+++ b/tests/MercadoPago/Client/PaymentMethod/PaymentMethodClientITTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace MercadoPago\Client\PaymentMethod;
+namespace MercadoPago\Tests\Client\PaymentMethod;
 
+use MercadoPago\Client\PaymentMethod\PaymentMethodClient;
 use MercadoPago\Core\MPRequestOptions;
 use MercadoPago\Exceptions\MPApiException;
 use MercadoPago\MercadoPagoConfig;

--- a/tests/MercadoPago/Client/PaymentMethod/PaymentMethodClientUnitTest.php
+++ b/tests/MercadoPago/Client/PaymentMethod/PaymentMethodClientUnitTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace MercadoPago\Client\PaymentMethod;
+namespace MercadoPago\Tests\Client\PaymentMethod;
 
+use MercadoPago\Client\PaymentMethod\PaymentMethodClient;
 use MercadoPago\MercadoPagoConfig;
 use MercadoPago\Net\MPDefaultHttpClient;
 use PHPUnit\Framework\TestCase;

--- a/tests/MercadoPago/Client/PreApproval/PreApprovalClientITTest.php
+++ b/tests/MercadoPago/Client/PreApproval/PreApprovalClientITTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace MercadoPago\Client\PreApproval;
+namespace MercadoPago\Tests\Client\PreApproval;
 
 use MercadoPago\Client\PreApproval\PreApprovalClient;
 use MercadoPago\Core\MPRequestOptions;

--- a/tests/MercadoPago/Client/PreApproval/PreApprovalClientUnitTest.php
+++ b/tests/MercadoPago/Client/PreApproval/PreApprovalClientUnitTest.php
@@ -1,10 +1,11 @@
 <?php
 
-namespace MercadoPago\Client\PreApproval;
+namespace MercadoPago\Tests\Client\PreApproval;
 
+use MercadoPago\Client\PreApproval\PreApprovalClient;
 use MercadoPago\MercadoPagoConfig;
 use MercadoPago\Net\MPDefaultHttpClient;
-use MercadoPago\Client\Base\BaseClient;
+use MercadoPago\Tests\Client\Base\BaseClient;
 
 /**
  * PreApproval Client unit tests.

--- a/tests/MercadoPago/Client/PreApprovalPlan/PreApprovalPlanClientITTest.php
+++ b/tests/MercadoPago/Client/PreApprovalPlan/PreApprovalPlanClientITTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace MercadoPago\Client\PreApprovalPlan;
+namespace MercadoPago\Tests\Client\PreApprovalPlan;
 
+use MercadoPago\Client\PreApprovalPlan\PreApprovalPlanClient;
 use MercadoPago\Core\MPRequestOptions;
 use MercadoPago\Exceptions\MPApiException;
 use MercadoPago\MercadoPagoConfig;

--- a/tests/MercadoPago/Client/PreApprovalPlan/PreApprovalPlanClientUnitTest.php
+++ b/tests/MercadoPago/Client/PreApprovalPlan/PreApprovalPlanClientUnitTest.php
@@ -1,10 +1,11 @@
 <?php
 
-namespace MercadoPago\Client\PreApprovalPlan;
+namespace MercadoPago\Tests\Client\PreApprovalPlan;
 
+use MercadoPago\Client\PreApprovalPlan\PreApprovalPlanClient;
 use MercadoPago\MercadoPagoConfig;
 use MercadoPago\Net\MPDefaultHttpClient;
-use MercadoPago\Client\Base\BaseClient;
+use MercadoPago\Tests\Client\Base\BaseClient;
 
 /**
  * PreApprovalPlan Client unit tests.

--- a/tests/MercadoPago/Client/Preference/PreferenceClientITTest.php
+++ b/tests/MercadoPago/Client/Preference/PreferenceClientITTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace MercadoPago\Client\Preference;
+namespace MercadoPago\Tests\Client\Preference;
 
 use MercadoPago\Client\Preference\PreferenceClient;
 use MercadoPago\Core\MPRequestOptions;

--- a/tests/MercadoPago/Client/Preference/PreferenceClientUnitTest.php
+++ b/tests/MercadoPago/Client/Preference/PreferenceClientUnitTest.php
@@ -1,10 +1,11 @@
 <?php
 
-namespace MercadoPago\Client\Preference;
+namespace MercadoPago\Tests\Client\Preference;
 
+use MercadoPago\Client\Preference\PreferenceClient;
 use MercadoPago\MercadoPagoConfig;
 use MercadoPago\Net\MPDefaultHttpClient;
-use MercadoPago\Client\Base\BaseClient;
+use MercadoPago\Tests\Client\Base\BaseClient;
 
 /**
  * Preference Client unit tests.

--- a/tests/MercadoPago/Client/User/UserClientITTest.php
+++ b/tests/MercadoPago/Client/User/UserClientITTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace MercadoPago\Client\User;
+namespace MercadoPago\Tests\Client\User;
 
+use MercadoPago\Client\User\UserClient;
 use MercadoPago\Core\MPRequestOptions;
 use MercadoPago\Exceptions\MPApiException;
 use MercadoPago\MercadoPagoConfig;

--- a/tests/MercadoPago/Client/User/UserClientUnitTest.php
+++ b/tests/MercadoPago/Client/User/UserClientUnitTest.php
@@ -1,10 +1,11 @@
 <?php
 
-namespace MercadoPago\Client\User;
+namespace MercadoPago\Tests\Client\User;
 
+use MercadoPago\Client\User\UserClient;
 use MercadoPago\MercadoPagoConfig;
 use MercadoPago\Net\MPDefaultHttpClient;
-use MercadoPago\Client\Base\BaseClient;
+use MercadoPago\Tests\Client\Base\BaseClient;
 
 /**
  * UserClientUnitTest Client unit tests.

--- a/tests/MercadoPago/MercadoPagoConfigTest.php
+++ b/tests/MercadoPago/MercadoPagoConfigTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace MercadoPago;
+namespace MercadoPago\Tests;
 
+use MercadoPago\MercadoPagoConfig;
 use MercadoPago\Net\MPDefaultHttpClient;
 use PHPUnit\Framework\TestCase;
 


### PR DESCRIPTION
## Description

> Classes needed to run the test suite should not be included in the main autoload rules to avoid polluting the autoloader in production and when other people use your package as a dependency.
Therefore, it is a good idea to rely on a dedicated path for your unit tests and to add it within the autoload-dev section.

https://getcomposer.org/doc/04-schema.md#autoload-dev