### PR TITLE
Add Idempotency Key

### DIFF
--- a/src/MercadoPago/Client/MercadoPagoClient.php
+++ b/src/MercadoPago/Client/MercadoPagoClient.php
@@ -64,7 +64,6 @@ class MercadoPagoClient
         $headers = array();
         $headers = $this->addCustomHeaders($headers, $request_options);
         $headers = $this->addDefaultHeaders($method, $headers, $request_options);
-        var_dump($headers);
         return $headers;
     }
 


### PR DESCRIPTION
## Description

This PR adds the `X-Idempotency-Key` header to all POST, PUT and PATCH requests.
Users can enter their own value in the header, but otherwise a UUID will be generated and sent.

### UUID Generation

The `generateUUID()` function uses the `sprintf()` function to format and assemble the UUID type 4. Let's analyze each part of the code:

- `%04x%04x-%04x-%04x-%04x-%04x%04x%04x`: It is the formatting string that represents the UUID type 4 format. Each `%04x` represents a 4-digit hexadecimal value .

- `mt_rand(0, 0xffff)`: Generates a random number between 0 and 65535 (0xffff in hexadecimal). This part is responsible for generating the 32 bits of the "time_low" field.

- `mt_rand(0, 0xffff)`: Generates a random number between 0 and 65535 (0xffff in hexadecimal). This part is responsible for generating the 32 bits of the "time_low" field.

- `mt_rand(0, 0xffff)`: Generates a random number between 0 and 65535 (0xffff in hexadecimal). This part is responsible for generating the 16 bits of the "time_mid" field.

- `mt_rand(0, 0x0fff) | 0x4000`: Generates a random number between 0 and 4095 (0x0fff in hexadecimal) and applies the OR operation with 0x4000 (representing version 4). This part is responsible for generating the 16 bits of the "time_hi_and_version" field.

- `mt_rand(0, 0x3fff) | 0x8000`: Generates a random number between 0 and 16383 (0x3fff in hexadecimal) and applies the OR operation with 0x8000 (representing the DCE1.1 variant). This part is responsible for generating the 16 bits of the "clk_seq_hi_res" and "clk_seq_low" fields.

- `mt_rand(0, 0xffff)`: Generates a random number between 0 and 65535 (0xffff in hexadecimal). This part is responsible for generating the 16 most significant bits of the "node" field.

- `mt_rand(0, 0xffff)`: Generates a random number between 0 and 65535 (0xffff in hexadecimal). This part is responsible for generating the 16 bits of the "node" field.

- `mt_rand(0, 0xffff)`: Generates a random number between 0 and 65535 (0xffff in hexadecimal). This part is responsible for generating the 16 least significant bits of the "node" field.

The `generateUUID()` function returns the randomly generated type 4 UUID, assembled according to the format specified in the format string.