### PR TITLE
Improve RecuperableError cause processing

### DIFF
--- a/src/MercadoPago/Generic/RecuperableError.php
+++ b/src/MercadoPago/Generic/RecuperableError.php
@@ -31,7 +31,16 @@ class RecuperableError {
                 if(is_array($cause) && (!isset($cause['code']) && !isset($cause['description']))){
                     $this->proccess_causes($cause);
                 }else{
-                    $this->add_cause($cause['code'], $cause['description']);
+                    $code = isset($cause['code']) ? $cause['code'] : "";
+                    $description = $cause;
+                    if (is_array($cause)) {
+                        if (isset($cause['description'])) {
+                            $description = $cause['description'];
+                        } elseif (isset($cause['message'])) {
+                            $description = $cause['message'];
+                        }
+                    }
+                    $this->add_cause($code, $description);
                 }
             }
         }


### PR DESCRIPTION
## Description
Improves error handling if an API does not return as desired.
If there is no `description` or `message` field, the complete error will be sent within `description` so that the error is not hidden from the integrator.