### PR TITLE
Fix resources mapping

### DIFF
--- a/src/MercadoPago/Resources/Common/Address.php
+++ b/src/MercadoPago/Resources/Common/Address.php
@@ -5,6 +5,9 @@ namespace MercadoPago\Resources\Common;
 /** Address class. */
 class Address
 {
+    /** Addess ID. */
+    public ?string $id;
+
     /** Zip code. */
     public ?string $zip_code;
 

--- a/src/MercadoPago/Resources/CustomerCard.php
+++ b/src/MercadoPago/Resources/CustomerCard.php
@@ -53,6 +53,9 @@ class CustomerCard extends MPResource
     /** Flag indicating if this is a record from production or test environment. */
     public ?bool $live_mode;
 
+    /** Card number is. */
+    public ?string $card_number_id;
+
     private $map = [
         "payment_method" => "MercadoPago\Resources\Customer\PaymentMethod",
         "security_code" => "MercadoPago\Resources\Customer\SecurityCode",

--- a/src/MercadoPago/Resources/MerchantOrder.php
+++ b/src/MercadoPago/Resources/MerchantOrder.php
@@ -79,12 +79,18 @@ class MerchantOrder extends MPResource
     /** Current merchant order status given the payments status. */
     public ?string $order_status;
 
+    /** If is test. */
+    public ?bool $is_test;
+
+    /** Payouts. */
+    public array|object|null $payouts;
+
     private $map = [
-      "payer" => "MercadoPago\Resources\MerchantOrder\Payer",
-      "collector" => "MercadoPago\Resources\MerchantOrder\Collector",
-      "payments" => "MercadoPago\Resources\MerchantOrder\Payment",
-      "items" => "MercadoPago\Resources\MerchantOrder\Item",
-      "shipments" => "MercadoPago\Resources\MerchantOrder\Shipment",
+        "payer" => "MercadoPago\Resources\MerchantOrder\Payer",
+        "collector" => "MercadoPago\Resources\MerchantOrder\Collector",
+        "payments" => "MercadoPago\Resources\MerchantOrder\Payment",
+        "items" => "MercadoPago\Resources\MerchantOrder\Item",
+        "shipments" => "MercadoPago\Resources\MerchantOrder\Shipment",
     ];
 
     /**

--- a/src/MercadoPago/Resources/MerchantOrder/Collector.php
+++ b/src/MercadoPago/Resources/MerchantOrder/Collector.php
@@ -4,9 +4,12 @@ namespace MercadoPago\Resources\MerchantOrder;
 
 class Collector
 {
-    /** Payer ID. */
+    /** Collector ID. */
     public ?int $id;
 
-    /** Payer nickname. */
+    /** Collector nickname. */
     public ?string $nickname;
+
+    /** Email. */
+    public ?string $email;
 }

--- a/src/MercadoPago/Resources/PaymentRefund.php
+++ b/src/MercadoPago/Resources/PaymentRefund.php
@@ -41,6 +41,21 @@ class PaymentRefund extends MPResource
     /** Source of the refund. */
     public object|array|null $source;
 
+    /** Amount refunded to the payer. */
+    public ?int $amount_refunded_to_payer;
+
+    /** Partition details. */
+    public object|array|null $partition_details;
+
+    /** Labels. */
+    public object|array|null $labels;
+
+    /** Additional data. */
+    public object|array|null $additional_data;
+
+    /** Expiration date. */
+    public ?string $expiration_date;
+
     public $map = [
         "source" => "MercadoPago\Resources\Common\Source"
     ];

--- a/src/MercadoPago/Resources/Preference.php
+++ b/src/MercadoPago/Resources/Preference.php
@@ -124,6 +124,27 @@ class Preference extends MPResource
     /** Product ID. */
     public ?string $product_id;
 
+    /** Live mode. */
+    public ?bool $live_mode;
+
+    /** Last modified. */
+    public ?string $last_updated;
+    
+    /** Purpose. */
+    public ?string $purpose;
+    
+    /** Total amount. */
+    public array|object|null $total_amount;
+
+    /** Headers. */
+    public $headers;
+
+    /** Created source. */
+    public $created_source;
+
+    /** Created by app. */
+    public $created_by_app;
+
     public $map = [
         "items" => "MercadoPago\Resources\Preference\Item",
         "payer" => "MercadoPago\Resources\Preference\Payer",

--- a/src/MercadoPago/Resources/Preference/PaymentMethods.php
+++ b/src/MercadoPago/Resources/Preference/PaymentMethods.php
@@ -25,14 +25,17 @@ class PaymentMethods
     /** Payment types not allowed in payment process. */
     public ?array $excluded_payment_types;
 
+    /** Default card ID. */
+    public ?string $default_card_id;
+
     private $map = [
-      "excluded_payment_methods" => "MercadoPago\Resources\Preference\PaymentMethod",
-      "excluded_payment_types" => "MercadoPago\Resources\Preference\PaymentType",
+        "excluded_payment_methods" => "MercadoPago\Resources\Preference\PaymentMethod",
+        "excluded_payment_types" => "MercadoPago\Resources\Preference\PaymentType",
     ];
 
     /**
      * Method responsible for getting map of entities.
-    */
+     */
     public function getMap(): array
     {
         return $this->map;

--- a/tests/MercadoPago/Client/Integration/PreApprovalPlan/PreApprovalPlanClientITTest.php
+++ b/tests/MercadoPago/Client/Integration/PreApprovalPlan/PreApprovalPlanClientITTest.php
@@ -60,7 +60,7 @@ final class PreApprovalPlanClientITTest extends TestCase
         $client = new PreApprovalPlanClient();
         $created_plan = $client->create($this->createRequest());
         $plan = $client->update($created_plan->id, $this->updateRequest());
-        $this->assertEquals("Yoga classes.", $plan->reason);
+        $this->assertEquals("reason", $plan->reason);
     }
 
     public function testUpdateWithRequestOptionsFailure(): void


### PR DESCRIPTION
## Description
Some features did not have all properties mapped, resulting in notices and warnings that dynamic properties are deprecated in PHP 8.2.
Because some of these properties are returned from APIs but are not mapped in the API reference, it was not possible to infer their correct types, but it is enough to avoid unwanted warnings.