### PR TITLE
Runtime enviroment (skip SSL on localhost)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ That's it! Mercado Pago SDK has been successfully installed.
 
 Here you can check eg. data structures for each parameter used by the SDK for each class.
 
-## 🌟 Getting Started with payment data collected in your own website forms
+## 🌟 Getting Started with payment via your own website forms
 
 Simple usage looks like:
 
@@ -134,19 +134,19 @@ $payment = $client->create($request);
 ### Step 6: Handle exceptions
 
 ```php
-...
-// Handle API exceptions
+try{
+    // Do your stuff here
 } catch (MPApiException $e) {
+    // Handle API exceptions
     echo "Status code: " . $e->getApiResponse()->getStatusCode() . "\n";
     echo "Content: " . $e->getApiResponse()->getContent() . "\n";
-
-// Handle all other exceptions
 } catch (\Exception $e) {
+    // Handle all other exceptions
     echo $e->getMessage();
 }
 ```
 
-## 🌟 Getting started with payment data collected via Checkout Pro
+## 🌟 Getting started with payment via Checkout Pro
 
 ### Step 1: Require the libraries
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Simple usage looks like:
 
     // Step 2: Set production or sandbox access token
     MercadoPagoConfig::setAccessToken("<ACCESS_TOKEN>");
+    // Step 2.2: Set your runtime enviroment from MercadoPagoConfig::RUNTIME_ENVIROMENTS (default is SERVER)
+    MercadoPagoConfig::setRuntimeEnviroment(MercadoPagoConfig::RUNTIME_ENVIROMENTS::LOCAL);
 
     // Step 3: Initialize the API client
     $client = new PaymentClient();
@@ -77,6 +79,7 @@ Simple usage looks like:
 ```
 
 ### Step 1: Require the library from your Composer vendor folder
+
 ```php
 require_once 'vendor/autoload.php';
 
@@ -86,6 +89,7 @@ use MercadoPago\MercadoPagoConfig;
 ```
 
 ### Step 2: Set production or sandbox access token
+
 ```php
 MercadoPagoConfig::setAccessToken("<ACCESS_TOKEN>");
 ```
@@ -93,11 +97,13 @@ MercadoPagoConfig::setAccessToken("<ACCESS_TOKEN>");
 You can also set another properties as quantity of retries, tracking headers, timeouts and a custom http client.
 
 ### Step 3: Initialize the API client
+
 ```php
 $client = new PaymentClient();
 ```
 
 ### Step 4: Create the request array
+
 ```php
 $request = [
     "transaction_amount" => 100,
@@ -112,11 +118,13 @@ $request = [
 ```
 
 ### Step 5: Make the request
+
 ```php
 $payment = $client->create($request);
 ```
 
 ### Step 6: Handle exceptions
+
 ```php
 ...
 // Handle API exceptions
@@ -144,6 +152,7 @@ Please read and follow our [contribution guidelines](CONTRIBUTING.md). Contribut
 be disregarded. The guidelines are in place to make all of our lives easier and make contribution a consistent process for everyone.
 
 ### Patches to version 2.x.x
+
 Since the release of version 3.0.0, version 2 is deprecated and will not be receiving new features, only bug fixes. If you need to submit PRs for that version, please do so by using [master-v2](https://github.com/mercadopago/sdk-php/tree/master-v2) as your base branch.
 
 ## ❤️ Support

--- a/README.md
+++ b/README.md
@@ -154,7 +154,6 @@ try{
 use MercadoPago\MercadoPagoConfig;
 use MercadoPago\Client\Preference\PreferenceClient;
 use MercadoPago\Exceptions\MPApiException;
-use Log;
 ```
 
 ### Step 2: Create an authentication function
@@ -253,8 +252,6 @@ public function createPaymentPreference(): ?Preference
         // Useful props you could use from this object is 'init_point' (URL to Checkout Pro) or the 'id'
         return $preference;
     } catch (MPApiException $error) {
-        Log::debug("Error creating Preference: " . $error->getApiResponse());
-
         // Here you might return whatever your app needs.
         // We are returning null here as an example.
         return null;

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Simple usage looks like:
 
     // Step 2: Set production or sandbox access token
     MercadoPagoConfig::setAccessToken("<ACCESS_TOKEN>");
-    // Step 2.2: Set your runtime enviroment from MercadoPagoConfig::RUNTIME_ENVIROMENTS (default is SERVER)
+    // Step 2.1 (optional - default is SERVER): Set your runtime enviroment from MercadoPagoConfig::RUNTIME_ENVIROMENTS
     MercadoPagoConfig::setRuntimeEnviroment(MercadoPagoConfig::RUNTIME_ENVIROMENTS::LOCAL);
 
     // Step 3: Initialize the API client

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ function createPreferenceRequest($items, $payer): array
 }
 ```
 
-### Step 4: Create the preference on Mercado Pago and retrieve it's ID [docs](https://www.mercadopago.com.br/developers/pt/docs/sdks-library/server-side/php/preferences)
+### Step 4: Create the preference on Mercado Pago ([DOCS](https://www.mercadopago.com.br/developers/pt/docs/sdks-library/server-side/php/preferences))
 
 ```php
 public function createPaymentPreference(): ?Preference

--- a/src/MercadoPago/Exceptions/InvalidArgumentException.php
+++ b/src/MercadoPago/Exceptions/InvalidArgumentException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace MercadoPago\Exceptions;
+
+use Exception;
+
+/** InvalidArgumentException class. */
+class InvalidArgumentException extends Exception
+{
+}

--- a/src/MercadoPago/MercadoPagoConfig.php
+++ b/src/MercadoPago/MercadoPagoConfig.php
@@ -231,7 +231,7 @@ class MercadoPagoConfig
      * Gets the enviroment the user is running at.
      * @return string enviroment
      */
-    public static function getEnviroment(): string
+    public static function getRuntimeEnviroment(): string
     {
         return self::$RUNTIME_ENVIROMENT;
     }
@@ -241,7 +241,7 @@ class MercadoPagoConfig
      * @param string $enviroment one of the ENVIROMENT_TYPES
      * @return void
      */
-    public static function setEnviroment(string $enviroment): void
+    public static function setRuntimeEnviroment(string $enviroment): void
     {
         if (!in_array($enviroment, self::RUNTIME_ENVIROMENTS)) {
             throw new InvalidArgumentException("Enviroment must be equal to one of the options in MercadoPagoConfig::RUNTIME_ENVIROMENTS.");

--- a/src/MercadoPago/MercadoPagoConfig.php
+++ b/src/MercadoPago/MercadoPagoConfig.php
@@ -25,7 +25,7 @@ class MercadoPagoConfig
     const SERVER = 'server';
 
     /** @var string Actual enviroment the user is running at. Default is SERVER */
-    private static string $runtime_enviroment = self::LOCAL;
+    private static string $runtime_enviroment = self::SERVER;
 
     /** @var string access token */
     private static string $access_token = "";

--- a/src/MercadoPago/MercadoPagoConfig.php
+++ b/src/MercadoPago/MercadoPagoConfig.php
@@ -5,6 +5,7 @@ namespace MercadoPago;
 use MercadoPago\Exceptions\InvalidArgumentException;
 use MercadoPago\Net\MPDefaultHttpClient;
 use MercadoPago\Net\MPHttpClient;
+use App\Enum;
 
 /** Mercado Pago configuration class. */
 class MercadoPagoConfig
@@ -18,14 +19,14 @@ class MercadoPagoConfig
     /** @var string Mercado Pago SDK PHP product version */
     public static string $PRODUCT_ID = "BC32A7RU643001OI3940";
 
-    /** @var array Types of enviroments the user can run at (local machine or server) */
-    public const RUNTIME_ENVIROMENTS = [
-        self::LOCAL => 'local',
-        self::SERVER => 'server'
-    ];
+    /** @var string Class constant for local runtime enviroment */
+    const LOCAL = 'local';
+
+    /** @var string Class constant for server runtime enviroment */
+    const SERVER = 'server';
 
     /** @var string Actual enviroment the user is running at. Default is SERVER */
-    private static string $RUNTIME_ENVIROMENT = self::RUNTIME_ENVIROMENTS::LOCAL;
+    private static string $runtime_enviroment = self::LOCAL;
 
     /** @var string access token */
     private static string $access_token = "";
@@ -233,7 +234,7 @@ class MercadoPagoConfig
      */
     public static function getRuntimeEnviroment(): string
     {
-        return self::$RUNTIME_ENVIROMENT;
+        return self::$runtime_enviroment;
     }
 
     /**
@@ -243,9 +244,9 @@ class MercadoPagoConfig
      */
     public static function setRuntimeEnviroment(string $enviroment): void
     {
-        if (!in_array($enviroment, self::RUNTIME_ENVIROMENTS)) {
-            throw new InvalidArgumentException("Enviroment must be equal to one of the options in MercadoPagoConfig::RUNTIME_ENVIROMENTS.");
+        if ($enviroment != self::LOCAL && $enviroment != self::SERVER) {
+            throw new InvalidArgumentException("Enviroment must be equal to MercadoPagoConfig::LOCAL or MercadoPagoConfig::SERVER.");
         }
-        self::$ENVIROMENT = $enviroment;
+        self::$runtime_enviroment = $enviroment;
     }
 }

--- a/src/MercadoPago/MercadoPagoConfig.php
+++ b/src/MercadoPago/MercadoPagoConfig.php
@@ -2,6 +2,7 @@
 
 namespace MercadoPago;
 
+use MercadoPago\Exceptions\InvalidArgumentException;
 use MercadoPago\Net\MPDefaultHttpClient;
 use MercadoPago\Net\MPHttpClient;
 
@@ -16,6 +17,15 @@ class MercadoPagoConfig
 
     /** @var string Mercado Pago SDK PHP product version */
     public static string $PRODUCT_ID = "BC32A7RU643001OI3940";
+
+    /** @var array Types of enviroments the user can run at (local machine or server) */
+    public const RUNTIME_ENVIROMENTS = [
+        self::LOCAL => 'local',
+        self::SERVER => 'server'
+    ];
+
+    /** @var string Actual enviroment the user is running at. Default is SERVER */
+    private static string $RUNTIME_ENVIROMENT = self::RUNTIME_ENVIROMENTS::LOCAL;
 
     /** @var string access token */
     private static string $access_token = "";
@@ -215,5 +225,27 @@ class MercadoPagoConfig
     public static function setConnectionTimeout(int $connection_timeout): void
     {
         self::$connection_timeout = $connection_timeout;
+    }
+
+    /**
+     * Gets the enviroment the user is running at.
+     * @return string enviroment
+     */
+    public static function getEnviroment(): string
+    {
+        return self::$RUNTIME_ENVIROMENT;
+    }
+
+    /**
+     * Sets the enviroment the user is running at.
+     * @param string $enviroment one of the ENVIROMENT_TYPES
+     * @return void
+     */
+    public static function setEnviroment(string $enviroment): void
+    {
+        if (!in_array($enviroment, self::RUNTIME_ENVIROMENTS)) {
+            throw new InvalidArgumentException("Enviroment must be equal to one of the options in MercadoPagoConfig::RUNTIME_ENVIROMENTS.");
+        }
+        self::$ENVIROMENT = $enviroment;
     }
 }

--- a/src/MercadoPago/MercadoPagoConfig.php
+++ b/src/MercadoPago/MercadoPagoConfig.php
@@ -5,7 +5,6 @@ namespace MercadoPago;
 use MercadoPago\Exceptions\InvalidArgumentException;
 use MercadoPago\Net\MPDefaultHttpClient;
 use MercadoPago\Net\MPHttpClient;
-use App\Enum;
 
 /** Mercado Pago configuration class. */
 class MercadoPagoConfig

--- a/src/MercadoPago/Net/MPDefaultHttpClient.php
+++ b/src/MercadoPago/Net/MPDefaultHttpClient.php
@@ -58,8 +58,6 @@ class MPDefaultHttpClient implements MPHttpClient
     private function makeRequest(MPRequest $request): MPResponse
     {
         $request_options = $this->createHttpRequestOptions($request);
-        error_log("request_options");
-        error_log(json_encode($request_options));
         $this->httpRequest->setOptionArray($request_options);
         $api_result = $this->httpRequest->execute();
         $status_code = $this->httpRequest->getInfo(CURLINFO_HTTP_CODE);

--- a/src/MercadoPago/Net/MPDefaultHttpClient.php
+++ b/src/MercadoPago/Net/MPDefaultHttpClient.php
@@ -89,7 +89,7 @@ class MPDefaultHttpClient implements MPHttpClient
     {
         $connection_timeout = $request->getConnectionTimeout() ?: MercadoPagoConfig::getConnectionTimeout();
 
-        return array(
+        $options = array(
             CURLOPT_URL => MercadoPagoConfig::$BASE_URL . $request->getUri(),
             CURLOPT_CUSTOMREQUEST => $request->getMethod(),
             CURLOPT_HTTPHEADER => $request->getHeaders(),
@@ -98,6 +98,13 @@ class MPDefaultHttpClient implements MPHttpClient
             CURLOPT_MAXCONNECTS => MercadoPagoConfig::getMaxConnections(),
             CURLOPT_RETURNTRANSFER => true
         );
+
+        if (MercadoPagoConfig::getEnviroment() === MercadoPagoConfig::ENVIROMENT_TYPES::LOCAL) {
+            $options['CURLOPT_SSL_VERIFYHOST'] = false;
+            $options['CURLOPT_SSL_VERIFYPEER'] = false;
+        }
+
+        return $options;
     }
 
     private function isServerError(int $status_code): bool

--- a/src/MercadoPago/Net/MPDefaultHttpClient.php
+++ b/src/MercadoPago/Net/MPDefaultHttpClient.php
@@ -58,6 +58,8 @@ class MPDefaultHttpClient implements MPHttpClient
     private function makeRequest(MPRequest $request): MPResponse
     {
         $request_options = $this->createHttpRequestOptions($request);
+        error_log("request_options");
+        error_log(json_encode($request_options));
         $this->httpRequest->setOptionArray($request_options);
         $api_result = $this->httpRequest->execute();
         $status_code = $this->httpRequest->getInfo(CURLINFO_HTTP_CODE);
@@ -100,8 +102,8 @@ class MPDefaultHttpClient implements MPHttpClient
         );
 
         if (MercadoPagoConfig::getRuntimeEnviroment() === MercadoPagoConfig::LOCAL) {
-            $options['CURLOPT_SSL_VERIFYHOST'] = false;
-            $options['CURLOPT_SSL_VERIFYPEER'] = false;
+            $options += [CURLOPT_SSL_VERIFYHOST => false];
+            $options += [CURLOPT_SSL_VERIFYPEER => false];
         }
 
         return $options;

--- a/src/MercadoPago/Net/MPDefaultHttpClient.php
+++ b/src/MercadoPago/Net/MPDefaultHttpClient.php
@@ -99,7 +99,7 @@ class MPDefaultHttpClient implements MPHttpClient
             CURLOPT_RETURNTRANSFER => true
         );
 
-        if (MercadoPagoConfig::getEnviroment() === MercadoPagoConfig::ENVIROMENT_TYPES::LOCAL) {
+        if (MercadoPagoConfig::getRuntimeEnviroment() === MercadoPagoConfig::LOCAL) {
             $options['CURLOPT_SSL_VERIFYHOST'] = false;
             $options['CURLOPT_SSL_VERIFYPEER'] = false;
         }


### PR DESCRIPTION
## Changes made to the feature:
 * Added the possibility of bypassing SSL verification when the developer is running the app in localhost;
 * Patch on `MercadoPagoConfig` class, adding the field `runtime_enviroment` and class constants for LOCAL and SERVER options, as well as getter and setter for the `runtime_enviroment`;
 * Patch on `MPDefaultHttpClient` class, adding logic to the function `createHttpRequestOptions` that will allow the program to check if the dev has configured runtime enviroment to LOCAL, setting to false both `CURLOPT_SSL_VERIFYHOST` and `CURLOPT_SSL_VERIFYPEER` in options array in case he's set to LOCAL;
 * Created a `InvalidArgumentException` class (used in `MercadoPagoConfig->setRuntimeEnviroment()`).

## General changes
 * Added documented flows in README.md about Checkout Pro (Preferences creation)

## Issues closed
 * Closes #[486](https://github.com/mercadopago/sdk-php/discussions/486)
 
## OBS
* Unit tests not added considering there were no tests implemented for these existing classes


## PR validation checklist:

- [x] Title and clear description of the PR
- [x] Tests of my functionality
- [x] Documentation of my functionality
- [ ] Tests executed and passed
- [ ] Branch Coverage >= 80%
