### PR TITLE
Fix $city type

### DIFF
--- a/src/MercadoPago/Resources/Common/Address.php
+++ b/src/MercadoPago/Resources/Common/Address.php
@@ -2,9 +2,14 @@
 
 namespace MercadoPago\Resources\Common;
 
+use MercadoPago\Serialization\Mapper;
+
 /** Address class. */
 class Address
 {
+    /** Class mapper. */
+    use Mapper;
+
     /** Addess ID. */
     public ?string $id;
 
@@ -18,5 +23,17 @@ class Address
     public ?int $street_number;
 
     /** City. */
-    public ?string $city;
+    public array|object|null $city;
+
+    private $map = [
+        "city" => "MercadoPago\Resources\Common\City"
+    ];
+
+    /**
+     * Method responsible for getting map of entities.
+     */
+    public function getMap(): array
+    {
+        return $this->map;
+    }
 }

--- a/src/MercadoPago/Resources/Common/City.php
+++ b/src/MercadoPago/Resources/Common/City.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace MercadoPago\Resources\Common;
+
+/** City class. */
+class City
+{
+    /** City ID. */
+    public ?string $id;
+
+    /** City name. */
+    public ?string $name;
+}

--- a/tests/MercadoPago/Client/Integration/Customer/CustomerClientITTest.php
+++ b/tests/MercadoPago/Client/Integration/Customer/CustomerClientITTest.php
@@ -108,6 +108,7 @@ final class CustomerClientITTest extends TestCase
         $this->assertNotNull($search_result->results);
         $this->assertSame(1, count($search_result->results));
         $this->assertSame($created_customer->id, $search_result->results[0]->id);
+        $this->assertSame("São Paulo", $search_result->results[0]->address->city->name);
     }
 
     public function testSearchWithRequestOptionsFailure(): void
@@ -122,7 +123,13 @@ final class CustomerClientITTest extends TestCase
     private function createRequest(string $email): array
     {
         $request = [
-            "email" => $email
+            "email" => $email,
+            'address' => [
+                'zip_code' => '01001000',
+                'street_name' => 'Rua Exemplo',
+                'street_number' => 123,
+                'city' => ["name" => "São Paulo"]
+            ],
         ];
         return $request;
     }


### PR DESCRIPTION
## Changes made to the feature:
 * Fix `$city` type. This field is returned as a JSON with `id` and `name` in the customer/search response. 
The Address object is used in other responses, but any city parameter is returned.

## General changes
 * Changes `$city` type from `?string` to `array|object|null` and maps to new Common\City class. 

## Issues closed
 * Closes #492 

## PR validation checklist:

- [X] Title and clear description of the PR
- [X] Tests of my functionality
- [ ] Documentation of my functionality
- [X] Tests executed and passed
