### PR TITLE
Update Merchant Order response

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ First time using Mercado Pago? Create your [Mercado Pago account](https://www.me
 2. Install PHP SDK for MercadoPago running in command line:
 
 ```
-composer require "mercadopago/dx-php:3.0.3"
+composer require "mercadopago/dx-php:3.0.4"
 ```
 
 > You can also run _composer require "mercadopago/dx-php:2.6.2"_ for PHP7.1 or _composer require "mercadopago/dx-php:1.12.6"_ for PHP5.6.

--- a/src/MercadoPago/MercadoPagoConfig.php
+++ b/src/MercadoPago/MercadoPagoConfig.php
@@ -10,7 +10,7 @@ use MercadoPago\Net\MPHttpClient;
 class MercadoPagoConfig
 {
     /** @var string Mercado Pago SDK version. */
-    public static string $CURRENT_VERSION = "3.0.3";
+    public static string $CURRENT_VERSION = "3.0.4";
 
     /** @var string Mercado Pago Base URL */
     public static string $BASE_URL = "https://api.mercadopago.com";

--- a/src/MercadoPago/Resources/MerchantOrder/Payer.php
+++ b/src/MercadoPago/Resources/MerchantOrder/Payer.php
@@ -9,4 +9,7 @@ class Payer
 
     /** Payer nickname. */
     public ?string $nickname;
+
+    /** Payer email. */
+    public ?string $email;
 }

--- a/src/MercadoPago/Resources/MerchantOrder/Payment.php
+++ b/src/MercadoPago/Resources/MerchantOrder/Payment.php
@@ -22,6 +22,9 @@ class Payment
     /** Payment status. */
     public ?string $status;
 
+    /** @deprecated deprecated since SDK version 3.0.4. */
+    public ?string $status_details;
+
     /** Gives more detailed information on the current state or rejection cause. */
     public ?string $status_detail;
 

--- a/src/MercadoPago/Resources/MerchantOrder/Payment.php
+++ b/src/MercadoPago/Resources/MerchantOrder/Payment.php
@@ -23,7 +23,7 @@ class Payment
     public ?string $status;
 
     /** Gives more detailed information on the current state or rejection cause. */
-    public ?string $status_details;
+    public ?string $status_detail;
 
     /** Operation type. */
     public ?string $operation_type;


### PR DESCRIPTION
## Changes made to the feature:
 * Add `email` field to Merchant Order Payer response.
 * Update field `status_details` to `status_detail`, as indicated by the official documentation.
 * Uses [@deprecated](https://manual.phpdoc.org/HTMLSmartyConverter/PHP/phpDocumentor/tutorial_tags.deprecated.pkg.html) for `status_details`.

## Closes:
#502 

## PR validation checklist:

- [X] Title and clear description of the PR
- [X] Tests of my functionality
- [X] Documentation of my functionality
- [X] Tests executed and passed
- [X] Branch Coverage >= 80%
