### PR TITLE
Fix invoice client for alphanumeric external references and add missing resource fields

### DIFF
--- a/src/MercadoPago/Resources/Invoice.php
+++ b/src/MercadoPago/Resources/Invoice.php
@@ -38,8 +38,14 @@ class Invoice extends MPResource
     /** The transaction amount. */
     public ?float $transaction_amount;
 
+    /** The date for the next retry attempt. */
+    public ?string $next_retry_date;
+
     /** The debit date and time for the invoice. */
     public ?string $debit_date;
+
+    /** The payment method ID. */
+    public ?string $payment_method_id;
 
     /** The retry attempt count. */
     public ?int $retry_attempt;

--- a/src/MercadoPago/Resources/Invoice.php
+++ b/src/MercadoPago/Resources/Invoice.php
@@ -30,7 +30,7 @@ class Invoice extends MPResource
     public ?string $reason;
 
     /** The external reference for the invoice. */
-    public ?int $external_reference;
+    public ?string $external_reference;
 
     /** The currency ID. */
     public ?string $currency_id;

--- a/src/MercadoPago/Resources/Invoice/InvoiceSearchResult.php
+++ b/src/MercadoPago/Resources/Invoice/InvoiceSearchResult.php
@@ -29,7 +29,7 @@ class InvoiceSearchResult
     public ?string $reason;
 
     /** The external reference for the invoice. */
-    public ?int $external_reference;
+    public ?string $external_reference;
 
     /** The currency ID. */
     public ?string $currency_id;

--- a/tests/MercadoPago/Client/Unit/Invoice/InvoiceClientUnitTest.php
+++ b/tests/MercadoPago/Client/Unit/Invoice/InvoiceClientUnitTest.php
@@ -31,7 +31,7 @@ final class InvoiceClientUnitTest extends BaseClient
         $this->assertSame("2022-01-01T11:12:25.892-04:00", $invoice->last_modified);
         $this->assertSame("2c938084726fca480172750000000000", $invoice->preapproval_id);
         $this->assertSame("Yoga classes", $invoice->reason);
-        $this->assertSame(23546246234, $invoice->external_reference);
+        $this->assertSame("YG-23546246234", $invoice->external_reference);
         $this->assertSame("ARS", $invoice->currency_id);
         $this->assertSame(10.0, $invoice->transaction_amount);
         $this->assertSame("2022-01-01T11:12:25.892-04:00", $invoice->debit_date);

--- a/tests/MercadoPago/Resources/Mocks/Response/Invoice/invoice_base.json
+++ b/tests/MercadoPago/Resources/Mocks/Response/Invoice/invoice_base.json
@@ -5,7 +5,7 @@
     "last_modified": "2022-01-01T11:12:25.892-04:00",
     "preapproval_id": "2c938084726fca480172750000000000",
     "reason": "Yoga classes",
-    "external_reference": 23546246234,
+    "external_reference": "YG-23546246234",
     "currency_id": "ARS",
     "transaction_amount": 10,
     "debit_date": "2022-01-01T11:12:25.892-04:00",

--- a/tests/MercadoPago/Resources/Mocks/Response/Invoice/invoice_list.json
+++ b/tests/MercadoPago/Resources/Mocks/Response/Invoice/invoice_list.json
@@ -12,7 +12,7 @@
             "last_modified": "2022-01-01T11:12:25.892-04:00",
             "preapproval_id": "2c938084726fca480172750000000000",
             "reason": "Yoga classes",
-            "external_reference": 23546246234,
+            "external_reference": "YG-23546246234",
             "currency_id": "ARS",
             "transaction_amount": 10,
             "debit_date": "2022-01-01T11:12:25.892-04:00",


### PR DESCRIPTION
## General changes
 * Changes invoice external reference type from `int` to `string` to handle alphanumeric external references for some preapprovals.
 * Adds missing invoice resource fields.

## PR validation checklist:

- [x] Title and clear description of the PR
- [x] Tests of my functionality
- [x] Documentation of my functionality
- [x] Tests executed and passed
- [x] Branch Coverage >= 80%
