### PR TITLE
[Fix] Order, the order_id does not exists.

### DIFF
--- a/src/MercadoPago/Resources/Payment.php
+++ b/src/MercadoPago/Resources/Payment.php
@@ -26,11 +26,8 @@ class Payment extends MPResource
     /** Operation type. */
     public ?string $operation_type;
 
-    /** Order ID. */
-    public ?int $order_id;
-
     /** Order. */
-    public ?array $order;
+    public array|object|null $order;
 
     /** Brand ID. */
     public ?string $brand_id;
@@ -235,6 +232,7 @@ class Payment extends MPResource
         "payment_method" => "MercadoPago\Resources\Payment\PaymentMethod",
         "metadata" => "MercadoPago\Resources\Payment\Metadata",
         "three_ds_info" => "MercadoPago\Resources\Payment\ThreeDSInfo",
+        "order"=> "MercadoPago\Resources\Payment\Order"
     ];
 
     /**

--- a/src/MercadoPago/Resources/Payment/Order.php
+++ b/src/MercadoPago/Resources/Payment/Order.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace MercadoPago\Resources\Payment;
+
+/** Order class. */
+class Order
+{
+
+    /** Order ID. */
+    public ?int $id;
+
+    /** Type. */
+    public ?string $type;
+
+}


### PR DESCRIPTION
Add an Order.php to mapper on Payment class bacause order_id does not exists on payment GET requests, it works :), now we have the order->id on Payment objects
