### PR TITLE
Fix getAuthorizationURL method

### DIFF
--- a/src/MercadoPago/Client/OAuth/OAuthClient.php
+++ b/src/MercadoPago/Client/OAuth/OAuthClient.php
@@ -13,7 +13,7 @@ use MercadoPago\Serialization\Serializer;
 /** Client responsible for performing OAuth authorizartion. */
 final class OAuthClient extends MercadoPagoClient
 {
-    private const AUTH_URL = "https://auth.mercadopago.com";
+    private const AUTH_URL = "https://auth.mercadopago.com/authorization";
 
     private const URL = "/oauth/token";
 

--- a/tests/MercadoPago/Client/Unit/OAuth/OAuthClientUnitTest.php
+++ b/tests/MercadoPago/Client/Unit/OAuth/OAuthClientUnitTest.php
@@ -18,7 +18,7 @@ final class OAuthClientUnitTest extends BaseClient
     {
         $client = new OAuthClient();
         $url = $client->getAuthorizationURL("app_id", "redirect_uri", "random_id");
-        $expected = "https://auth.mercadopago.com?client_id=app_id&response_type=code&platform_id=mp&state=random_id&redirect_uri=redirect_uri";
+        $expected = "https://auth.mercadopago.com/authorization?client_id=app_id&response_type=code&platform_id=mp&state=random_id&redirect_uri=redirect_uri";
         $this->assertSame($expected, $url);
     }
 


### PR DESCRIPTION
Hello, 

I updated the `AUTH_URL` value because when using the `getAuthorizationURL` you actually land nowhere. 

<img width="1512" alt="Capture d’écran 2025-01-30 à 12 09 50" src="https://github.com/user-attachments/assets/76db74b3-7008-4a88-9eb8-2681aa25754a" />

On [this page](https://www.mercadopago.com.ar/developers/en/docs/checkout-pro/additional-content/security/oauth/creation) I found out that you need to reach the `/authorization` path. 
