### PR TITLE
fix: Remove payer_email from PreApproval classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,9 @@
 {
-    "name": "mercadopago/dx-php",
+    "name": "gabrielrbarbosa/dx-php",
     "description": "Mercado Pago PHP SDK",
     "type": "library",
     "license": "MIT",
-    "homepage": "https://github.com/mercadopago/sdk-php",
+    "homepage": "https://github.com/gabrielrbarbosa/sdk-php",
     "autoload": {
         "psr-4": {
             "MercadoPago\\": "src/MercadoPago"

--- a/src/MercadoPago/Resources/Point/PaymentIntentPayment.php
+++ b/src/MercadoPago/Resources/Point/PaymentIntentPayment.php
@@ -5,6 +5,9 @@ namespace MercadoPago\Resources\Point;
 /** PaymentIntentPayment class. */
 class PaymentIntentPayment
 {
+    /** Payment ID. */
+    public ?int $id;
+
     /** Number of installments for the payment. */
     public ?int $installments;
 

--- a/src/MercadoPago/Resources/PreApproval.php
+++ b/src/MercadoPago/Resources/PreApproval.php
@@ -17,9 +17,6 @@ class PreApproval extends MPResource
     /** Payer ID. */
     public ?int $payer_id;
 
-    /** Payer email. */
-    public ?string $payer_email;
-
     /** Return URL. */
     public ?string $back_url;
 

--- a/src/MercadoPago/Resources/PreApproval/PreApprovalListResult.php
+++ b/src/MercadoPago/Resources/PreApproval/PreApprovalListResult.php
@@ -16,9 +16,6 @@ class PreApprovalListResult
     /** Payer ID. */
     public ?int $payer_id;
 
-    /** Payer email. */
-    public ?string $payer_email;
-
     /** Return URL. */
     public ?string $back_url;
 


### PR DESCRIPTION
GET preapproval: https://www.mercadopago.com.br/developers/pt/reference/subscriptions/_preapproval_id/get
SEARCH preapproval: https://www.mercadopago.com.br/developers/pt/reference/subscriptions/_preapproval_search/get

[PR related](https://github.com/mercadopago/sdk-php/pull/437)
