### PR TITLE
[Feature] adding network transaction id related fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ First time using Mercado Pago? Create your [Mercado Pago account](https://www.me
 2. Install PHP SDK for MercadoPago running in command line:
 
 ```
-composer require "mercadopago/dx-php:3.4.0"
+composer require "mercadopago/dx-php:3.5.0"
 ```
 
 > You can also run _composer require "mercadopago/dx-php:2.6.2"_ for PHP7.1 or _composer require "mercadopago/dx-php:1.12.6"_ for PHP5.6.

--- a/src/MercadoPago/MercadoPagoConfig.php
+++ b/src/MercadoPago/MercadoPagoConfig.php
@@ -10,7 +10,7 @@ use MercadoPago\Net\MPHttpClient;
 class MercadoPagoConfig
 {
     /** @var string Mercado Pago SDK version. */
-    public static string $CURRENT_VERSION = "3.4.0";
+    public static string $CURRENT_VERSION = "3.5.0";
 
     /** @var string Mercado Pago Base URL */
     public static string $BASE_URL = "https://api.mercadopago.com";

--- a/src/MercadoPago/Resources/Payment.php
+++ b/src/MercadoPago/Resources/Payment.php
@@ -224,6 +224,9 @@ class Payment extends MPResource
     /** 3DS info. */
     public array|object|null $three_ds_info;
 
+    /** Expanded data. */
+    public array|object|null $expanded;
+
     private $map = [
         "forward_data" => "MercadoPago\Resources\Payment\ForwardData",
         "payer" => "MercadoPago\Resources\Payment\Payer",
@@ -235,7 +238,8 @@ class Payment extends MPResource
         "payment_method" => "MercadoPago\Resources\Payment\PaymentMethod",
         "metadata" => "MercadoPago\Resources\Payment\Metadata",
         "three_ds_info" => "MercadoPago\Resources\Payment\ThreeDSInfo",
-        "order"=> "MercadoPago\Resources\Payment\Order"
+        "order"=> "MercadoPago\Resources\Payment\Order",
+        "expanded" => "MercadoPago\Resources\Payment\Expanded"
     ];
 
     /**

--- a/src/MercadoPago/Resources/Payment/Expanded.php
+++ b/src/MercadoPago/Resources/Payment/Expanded.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace MercadoPago\Resources\Payment;
+
+use MercadoPago\Serialization\Mapper;
+
+/** Expanded class. */
+class Expanded
+{
+    /** Class mapper. */
+    use Mapper;
+
+    /** Gateway data. */
+    public ?object $gateway;
+
+    private $map = [
+        "gateway" => "MercadoPago\Resources\Payment\ExpandedGateway",
+    ];
+
+    /**
+     * Method responsible for getting map of entities.
+     */
+    public function getMap(): array
+    {
+        return $this->map;
+    }
+}
+
+/** Gateway class for expanded response. */
+class ExpandedGateway
+{
+    /** Class mapper. */
+    use Mapper;
+
+    /** Reference data. */
+    public ?object $reference;
+
+    private $map = [
+        "reference" => "MercadoPago\Resources\Payment\ExpandedGatewayReference",
+    ];
+
+    /**
+     * Method responsible for getting map of entities.
+     */
+    public function getMap(): array
+    {
+        return $this->map;
+    }
+}
+
+/** GatewayReference class for expanded response. */
+class ExpandedGatewayReference
+{
+    /** Network transaction ID. */
+    public ?string $network_transaction_id;
+} 

--- a/src/MercadoPago/Resources/Payment/ForwardData.php
+++ b/src/MercadoPago/Resources/Payment/ForwardData.php
@@ -12,9 +12,11 @@ class ForwardData
 
     public array|object|null $sub_merchant;
 
+    public array|object|null $network_transaction_data;
 
     private $map = [
         "sub_merchant" => "MercadoPago\Resources\Common\SubMerchant",
+        "network_transaction_data" => "MercadoPago\Resources\Payment\NetworkTransactionData",
     ];
 
     /**

--- a/src/MercadoPago/Resources/Payment/NetworkTransactionData.php
+++ b/src/MercadoPago/Resources/Payment/NetworkTransactionData.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace MercadoPago\Resources\Payment;
+
+/** NetworkTransactionData class. */
+class NetworkTransactionData
+{
+    /** Network transaction ID. */
+    public ?string $network_transaction_id;
+} 


### PR DESCRIPTION
Adding network_transaction_id related fields to payments request and response. [Documentation](https://www.mercadopago.com.br/developers/pt/docs/automatic-payments/recurring-charges/network-transaction-id)
Request:

```
forward_data: {
     network_transaction_data: {
       network_transaction_id: "xxxxxxx"
     }
   }
```
Response:

```
"expanded": {
   "gateway": {
 	  "reference": {
 		 "network_transaction_id": "xxxxx"
 	    }
    }
}
```