### PR TITLE
[Fix] Fixing duplicated 'x-idempotency-key'

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ First time using Mercado Pago? Create your [Mercado Pago account](https://www.me
 2. Install PHP SDK for MercadoPago running in command line:
 
 ```
-composer require "mercadopago/dx-php:3.4.0"
+composer require "mercadopago/dx-php:3.4.1"
 ```
 
 > You can also run _composer require "mercadopago/dx-php:2.6.2"_ for PHP7.1 or _composer require "mercadopago/dx-php:1.12.6"_ for PHP5.6.

--- a/src/MercadoPago/Client/MercadoPagoClient.php
+++ b/src/MercadoPago/Client/MercadoPagoClient.php
@@ -115,7 +115,8 @@ class MercadoPagoClient
     private function headerExists(array $headers, string $header): bool
     {
         foreach($headers as $h) {
-            if (strtolower($h) == strtolower($header)) {
+            $headerName = trim(explode(':', $h, 2)[0]);
+            if (strtolower($headerName) == strtolower($header)) {
                 return true;
             }
         }

--- a/src/MercadoPago/MercadoPagoConfig.php
+++ b/src/MercadoPago/MercadoPagoConfig.php
@@ -10,7 +10,7 @@ use MercadoPago\Net\MPHttpClient;
 class MercadoPagoConfig
 {
     /** @var string Mercado Pago SDK version. */
-    public static string $CURRENT_VERSION = "3.4.0";
+    public static string $CURRENT_VERSION = "3.4.1";
 
     /** @var string Mercado Pago Base URL */
     public static string $BASE_URL = "https://api.mercadopago.com";


### PR DESCRIPTION
Fixing a bug that was causing duplication in the x-idempotency-key header.

Previously, the headerexists() function compared the name of the header set in the code ($header) with the name of the header and its content sent in the request ($h)

`if (strtolower($h) == strtolower($header))`
(if "x-idempotency-key:valor-enviado-no-header" == "x-idempotency-key")

Now it splits the header at ':' and compares only the names:
```
$headerName = trim(explode(':', $h, 2)[0]);
if (strtolower($headerName) == strtolower($header))
```