### PR TITLE
fix: OAuthClient.getAuthorizationURL did not generate valid authorization Urls

### DIFF
--- a/src/MercadoPago/Client/OAuth/OAuthClient.php
+++ b/src/MercadoPago/Client/OAuth/OAuthClient.php
@@ -13,7 +13,7 @@ use MercadoPago\Serialization\Serializer;
 /** Client responsible for performing OAuth authorizartion. */
 final class OAuthClient extends MercadoPagoClient
 {
-    private const AUTH_URL = "https://auth.mercadopago.com";
+    private const AUTH_URL = "https://auth.mercadopago.com/authorization";
 
     private const URL = "/oauth/token";
 

--- a/src/MercadoPago/Client/OAuth/OAuthClient.php
+++ b/src/MercadoPago/Client/OAuth/OAuthClient.php
@@ -32,14 +32,14 @@ final class OAuthClient extends MercadoPagoClient
     public function getAuthorizationURL(string $app_id, string $redirect_uri, string $random_id): string
     {
         $query_params = [
-            "client_id" => $app_id,
+            "client_id" => urlencode($app_id),
             "response_type" => "code",
             "platform_id" => "mp",
-            "state" => $random_id,
+            "state" => urlencode($random_id),
             "redirect_uri" => $redirect_uri
         ];
 
-        $query_string = http_build_query($query_params);
+        $query_string = implode('&', $query_params);
         return OAuthClient::AUTH_URL . '?' . $query_string;
     }
 

--- a/src/MercadoPago/Client/OAuth/OAuthClient.php
+++ b/src/MercadoPago/Client/OAuth/OAuthClient.php
@@ -32,14 +32,15 @@ final class OAuthClient extends MercadoPagoClient
     public function getAuthorizationURL(string $app_id, string $redirect_uri, string $random_id): string
     {
         $query_params = [
-            "client_id" => urlencode($app_id),
-            "response_type" => "code",
-            "platform_id" => "mp",
-            "state" => urlencode($random_id),
-            "redirect_uri" => $redirect_uri
+            "client_id=".urlencode($app_id),
+            "response_type=code",
+            "platform_id=mp",
+            "state=".urlencode($random_id),
+            "redirect_uri=".$redirect_uri
         ];
 
-        $query_string = implode('&', $query_params);
+        $query_string = implode('&',$query_params);
+
         return OAuthClient::AUTH_URL . '?' . $query_string;
     }
 

--- a/tests/MercadoPago/Client/Unit/OAuth/OAuthClientUnitTest.php
+++ b/tests/MercadoPago/Client/Unit/OAuth/OAuthClientUnitTest.php
@@ -18,7 +18,7 @@ final class OAuthClientUnitTest extends BaseClient
     {
         $client = new OAuthClient();
         $url = $client->getAuthorizationURL("app_id", "redirect_uri", "random_id");
-        $expected = "https://auth.mercadopago.com?client_id=app_id&response_type=code&platform_id=mp&state=random_id&redirect_uri=redirect_uri";
+        $expected = "https://auth.mercadopago.com/authorization?client_id=app_id&response_type=code&platform_id=mp&state=random_id&redirect_uri=redirect_uri";
         $this->assertSame($expected, $url);
     }
 


### PR DESCRIPTION
## Changes made to the feature:
 * Removed http_build_query for query string and manually added urlencode to query fields where necessary because redirect_url needs to be in plain text. With this small change the redirect_url will be kept, but the other parameters will be formatted correctly.
 * Replaced AUTH_URL with correct Url https://auth.mercadopago.com/authorization

## PR validation checklist:

- [x] Title and clear description of the PR
- [x] Tests of my functionality
- [x] Documentation of my functionality
- [x] Tests executed and passed
- [x] Branch Coverage >= 80%
