### PR TITLE
feat: Add $test_token to OAuthCreateRequest

### DIFF
--- a/src/MercadoPago/Client/OAuth/OAuthCreateRequest.php
+++ b/src/MercadoPago/Client/OAuth/OAuthCreateRequest.php
@@ -19,4 +19,7 @@ class OAuthCreateRequest
 
     /** Redirect URI. */
     public string $redirect_uri;
+    
+    /** Test Token */
+    public bool $test_token = false;
 }

--- a/src/MercadoPago/Client/OAuth/OAuthCreateRequest.php
+++ b/src/MercadoPago/Client/OAuth/OAuthCreateRequest.php
@@ -21,5 +21,5 @@ class OAuthCreateRequest
     public string $redirect_uri;
     
     /** Test Token */
-    public bool $test_token = false;
+    public string $test_token = "false";
 }


### PR DESCRIPTION
## Changes made to the feature:
 * Added missing field test_token to the OAuthCreateRequest class with default value 'false'.

Documentation: https://www.mercadopago.com.br/developers/pt/reference/oauth/_oauth_token/post

## PR validation checklist:

- [x] Title and clear description of the PR
- [ ] Tests of my functionality
- [ ] Documentation of my functionality
- [ ] Tests executed and passed
- [ ] Branch Coverage >= 80%
