### PR TITLE
Docs/changelog 3.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This project follows Keep a Changelog and Semantic Versioning.
+
+## [3.5.1] - 2025-08-28
+### Added
+- Adicionar e atualizar campos e testes
+
+### Changed
+- Adiciona/corrige testes em `OrderClientUnitTest`
+- Atualiza `.gitignore` para ignorar `.idea`
+
+### Fixed
+-
+
+### Deprecated
+-
+
+### Removed
+- Remove `.idea` do versionamento
+- Remove arquivos solicitados na revisão
+- Remove arquivos em branco vazios
+
+### Security
+-
+
+<!-- When releasing, duplicate the block below replacing X.Y.Z and date -->
+<!-- Example: ## [3.6.0] - 2025-08-27 -->
+
+ 
+
+

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ That's it! Mercado Pago SDK has been successfully installed.
 
 - [SDK Docs](https://www.mercadopago.com.br/developers/pt/docs/sdks-library/server-side)
 - [REST API (consumed by the SDK)](https://www.mercadopago.com.br/developers/en/reference)
+- [CHANGELOG](./CHANGELOG.md)
 
 Here you can check eg. data structures for each parameter used by the SDK for each class.
 


### PR DESCRIPTION
Atualiza para 3.5.1:
- Fecha CHANGELOG (3.5.1)
- Bump de versão no código (CURRENT_VERSION=3.5.1)
- README com comando de instalação 3.5.1