### PR TITLE
fix: add new properties to metadata

### DIFF
--- a/src/MercadoPago/Resources/Payment/Metadata.php
+++ b/src/MercadoPago/Resources/Payment/Metadata.php
@@ -7,4 +7,13 @@ class Metadata
 {
     /** Order number. */
     public ?string $order_number;
+
+    /** User type. **/
+    public ?string $user_type;
+
+    /** Preapproval ID. **/
+    public ?string $preapproval_id;
+
+    /** Available tries **/
+    public ?string $available_tries;
 }

--- a/src/MercadoPago/Resources/Payment/Metadata.php
+++ b/src/MercadoPago/Resources/Payment/Metadata.php
@@ -15,5 +15,5 @@ class Metadata
     public ?string $preapproval_id;
 
     /** Available tries **/
-    public ?string $available_tries;
+    public ?int $available_tries;
 }


### PR DESCRIPTION
The MercadoPago\Resources\Payment\Metadata class is currently missing the user_type, preapproval_id and available_tries properties, which is returned by the API when a payment is associated with a subscription