### PR TITLE
chore: add Dependabot version updates and dependency audit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,6 @@ updates:
       time: "09:00"
       timezone: "America/Bogota"
     open-pull-requests-limit: 5
-    reviewers:
-      - "mercadopago/backend-sdks"
     assignees:
       - "mercadopago/backend-sdks"
     labels:
@@ -35,8 +33,6 @@ updates:
       time: "09:00"
       timezone: "America/Bogota"
     open-pull-requests-limit: 1
-    reviewers:
-      - "mercadopago/backend-sdks"
     labels:
       - "dependencies"
       - "ci"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,44 @@
+# Dependabot version updates — sdk-php
+# Ubicación obligatoria: .github/dependabot.yml
+# Ecosistemas: composer (PHP) + github-actions
+version: 2
+
+updates:
+  # ── PHP / Composer ───────────────────────────────────────────────────
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Bogota"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "mercadopago/backend-sdks"
+    assignees:
+      - "mercadopago/backend-sdks"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  # ── GitHub Actions (CI) ──────────────────────────────────────────────
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Bogota"
+    open-pull-requests-limit: 1
+    reviewers:
+      - "mercadopago/backend-sdks"
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -24,3 +24,6 @@ jobs:
 
       - name: Run unit tests
         run: vendor/bin/phpunit --testsuite "Unit Tests"
+
+      - name: Dependency audit
+        run: composer audit


### PR DESCRIPTION
## Summary

- Add `.github/dependabot.yml` to enable proactive dependency updates (Composer + GitHub Actions), weekly on Mondays at 09:00 America/Bogota, assigned to `mercadopago/backend-sdks`, ignoring semver-major bumps
- Add dependency audit step to CI (`composer audit`) to close the Dependabot loop: PR opened → CI runs → audit confirms CVE resolved → merge

## Test plan

- [ ] Verify `.github/dependabot.yml` is valid (GitHub will show a check in Security → Dependabot after merge)
- [ ] Enable **Dependabot version updates** in Settings → Security & analysis
- [ ] Confirm CI audit step runs on next PR