### PR TITLE
feat(order): add prev_transaction_ref to StoredCredential DTO (IXE-679)

### DIFF
--- a/src/MercadoPago/Resources/Order/StoredCredential.php
+++ b/src/MercadoPago/Resources/Order/StoredCredential.php
@@ -26,4 +26,11 @@ class StoredCredential
 
     /** Whether this is the first payment in a series using these credentials. */
     public ?bool $first_payment;
+
+    /**
+     * Reference to the previous transaction in a recurring series. Required from the second
+     * charge onwards to link this payment to the original card-network authorization.
+     * Type: string (transaction ID).
+     */
+    public ?string $prev_transaction_ref;
 }


### PR DESCRIPTION
## Summary

- **StoredCredential.php** → added `$prev_transaction_ref: ?string` — the identifier of the previous transaction in a recurring series. Allows the API response to be correctly deserialized when the field is present.

## Notes on PHP architecture

PHP requests use plain associative arrays, so `prev_transaction_ref` can already be sent today without any code change. `StoredCredential.php` lives in `Resources/Order/` and is a **response DTO** only (used to deserialize the API response into a typed object). The existing `IntegrationData.php` response DTO was already present and required no changes.

## Context

Part of IXE-679: fields required for the Automatic Payments (recurring without CVV) flow in the Orders API were missing from the public SDKs. Companion PRs exist for Java, Go, .NET, Node.js, Python and Ruby.

## Test plan

- [x] `./vendor/bin/phpunit tests/MercadoPago/Client/Unit/Order/` — 15 tests, 81 assertions, 0 failures
- [ ] Integration tests (not run per policy)

Generated with [Claude Code](https://claude.com/claude-code)