### PR TITLE
Fix/preference metadata and webhook signature

### DIFF
--- a/src/MercadoPago/Serialization/Serializer.php
+++ b/src/MercadoPago/Serialization/Serializer.php
@@ -49,6 +49,8 @@ class Serializer
                     } else {
                         $object->$key = self::_deserializeFromJson($class_name, $value);
                     }
+                } elseif (property_exists($object, $key) && self::propertyAcceptsArray($object, $key)) {
+                    $object->{$key} = $value;
                 }
             } elseif (property_exists($object, $key)) {
                 $object->{$key} = $value;
@@ -56,5 +58,21 @@ class Serializer
         }
 
         return $object;
+    }
+
+    private static function propertyAcceptsArray(object $object, string $key): bool
+    {
+        $prop = new \ReflectionProperty($object, $key);
+        $type = $prop->getType();
+        if ($type === null) {
+            return true;
+        }
+        $types = $type instanceof \ReflectionUnionType ? $type->getTypes() : [$type];
+        foreach ($types as $t) {
+            if ($t->getName() === 'array') {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/MercadoPago/Webhook/WebhookSignatureValidator.php
+++ b/src/MercadoPago/Webhook/WebhookSignatureValidator.php
@@ -73,7 +73,7 @@ final class WebhookSignatureValidator
         $xRequestId = self::normalize($xRequestId);
         $dataId = self::normalize($dataId);
         $versions = $supportedVersions ?: self::DEFAULT_SUPPORTED_VERSIONS;
-        $now = $nowProvider ?? static fn(): int => (int) (microtime(true) * 1000);
+        $now = $nowProvider ?? static fn (): int => (int) (microtime(true) * 1000);
 
         if ($xSignature === null) {
             throw new InvalidWebhookSignatureException(
@@ -197,7 +197,7 @@ final class WebhookSignatureValidator
     {
         $parts = [];
         if ($dataId !== null) {
-            $parts[] = 'id:' . strtolower($dataId);
+            $parts[] = 'id:' . $dataId;
         }
 
         if ($requestId !== null) {

--- a/tests/MercadoPago/Client/Unit/Preference/PreferenceClientUnitTest.php
+++ b/tests/MercadoPago/Client/Unit/Preference/PreferenceClientUnitTest.php
@@ -33,6 +33,8 @@ final class PreferenceClientUnitTest extends BaseClient
         $this->assertSame("test name", $preference ->payer->name);
         $this->assertSame("test surname", $preference ->payer->surname);
         $this->assertSame("4567", $preference ->items[0]->id);
+        $this->assertSame("value", $preference->metadata["key"]);
+        $this->assertSame("custom_value", $preference->metadata["custom_field"]);
     }
 
     public function testGetSuccess(): void
@@ -57,6 +59,8 @@ final class PreferenceClientUnitTest extends BaseClient
         $this->assertSame("test name", $preference ->payer->name);
         $this->assertSame("test surname", $preference ->payer->surname);
         $this->assertSame("4567", $preference ->items[0]->id);
+        $this->assertSame("value", $preference->metadata["key"]);
+        $this->assertSame("custom_value", $preference->metadata["custom_field"]);
     }
 
     public function testUpdateSuccess(): void

--- a/tests/MercadoPago/Resources/Mocks/Response/Preference/preference_base.json
+++ b/tests/MercadoPago/Resources/Mocks/Response/Preference/preference_base.json
@@ -34,7 +34,7 @@
   ],
   "marketplace": "MP-MKT-5887075667929427",
   "marketplace_fee": 0,
-  "metadata": {},
+  "metadata": {"key": "value", "custom_field": "custom_value"},
   "notification_url": null,
   "operation_type": "regular_payment",
   "payer": {

--- a/tests/MercadoPago/Webhook/Unit/WebhookSignatureValidatorUnitTest.php
+++ b/tests/MercadoPago/Webhook/Unit/WebhookSignatureValidatorUnitTest.php
@@ -23,7 +23,7 @@ final class WebhookSignatureValidatorUnitTest extends TestCase
     {
         $parts = [];
         if ($dataId) {
-            $parts[] = 'id:' . strtolower($dataId);
+            $parts[] = 'id:' . $dataId;
         }
         if ($requestId) {
             $parts[] = 'request-id:' . $requestId;
@@ -40,30 +40,31 @@ final class WebhookSignatureValidatorUnitTest extends TestCase
 
     private static function validHash(): string
     {
-        return self::computeHash(self::DATA_ID_LOWER, self::REQUEST_ID, self::TS, self::SECRET);
+        return self::computeHash(self::DATA_ID_RAW, self::REQUEST_ID, self::TS, self::SECRET);
     }
 
     // case 1
-    public function testHappyPathLowercase(): void
+    public function testHappyPathUppercase(): void
     {
-        $header = self::buildHeader(self::validHash());
-        WebhookSignatureValidator::validate($header, self::REQUEST_ID, self::DATA_ID_LOWER, self::SECRET);
-        $this->assertTrue(true); // no throw expected
-    }
-
-    // case 2
-    public function testUppercaseDataIdIsLowercased(): void
-    {
+        $this->expectNotToPerformAssertions();
         $header = self::buildHeader(self::validHash());
         WebhookSignatureValidator::validate($header, self::REQUEST_ID, self::DATA_ID_RAW, self::SECRET);
-        $this->assertTrue(true);
+    }
+
+    // case 2 — MP sends data.id uppercase; validator must NOT lowercase it before computing HMAC
+    public function testUppercaseDataIdPreservedInManifest(): void
+    {
+        $this->expectNotToPerformAssertions();
+        $upperHash = self::computeHash(self::DATA_ID_RAW, self::REQUEST_ID, self::TS, self::SECRET);
+        $header = self::buildHeader($upperHash);
+        WebhookSignatureValidator::validate($header, self::REQUEST_ID, self::DATA_ID_RAW, self::SECRET);
     }
 
     // case 3
     public function testMalformedHeaderThrowsMalformed(): void
     {
         try {
-            WebhookSignatureValidator::validate('this-is-garbage', self::REQUEST_ID, self::DATA_ID_LOWER, self::SECRET);
+            WebhookSignatureValidator::validate('this-is-garbage', self::REQUEST_ID, self::DATA_ID_RAW, self::SECRET);
             $this->fail('expected throw');
         } catch (InvalidWebhookSignatureException $e) {
             $this->assertSame(SignatureFailureReason::MALFORMED_SIGNATURE_HEADER, $e->getReason());
@@ -75,7 +76,7 @@ final class WebhookSignatureValidatorUnitTest extends TestCase
     public function testMissingHeaderThrowsMissingHeader(): void
     {
         try {
-            WebhookSignatureValidator::validate(null, self::REQUEST_ID, self::DATA_ID_LOWER, self::SECRET);
+            WebhookSignatureValidator::validate(null, self::REQUEST_ID, self::DATA_ID_RAW, self::SECRET);
             $this->fail('expected throw');
         } catch (InvalidWebhookSignatureException $e) {
             $this->assertSame(SignatureFailureReason::MISSING_SIGNATURE_HEADER, $e->getReason());
@@ -86,7 +87,7 @@ final class WebhookSignatureValidatorUnitTest extends TestCase
     public function testMissingTsThrowsMissingTimestamp(): void
     {
         try {
-            WebhookSignatureValidator::validate('v1=' . self::validHash(), self::REQUEST_ID, self::DATA_ID_LOWER, self::SECRET);
+            WebhookSignatureValidator::validate('v1=' . self::validHash(), self::REQUEST_ID, self::DATA_ID_RAW, self::SECRET);
             $this->fail('expected throw');
         } catch (InvalidWebhookSignatureException $e) {
             $this->assertSame(SignatureFailureReason::MISSING_TIMESTAMP, $e->getReason());
@@ -97,7 +98,7 @@ final class WebhookSignatureValidatorUnitTest extends TestCase
     public function testMissingV1ThrowsMissingHash(): void
     {
         try {
-            WebhookSignatureValidator::validate('ts=' . self::TS, self::REQUEST_ID, self::DATA_ID_LOWER, self::SECRET);
+            WebhookSignatureValidator::validate('ts=' . self::TS, self::REQUEST_ID, self::DATA_ID_RAW, self::SECRET);
             $this->fail('expected throw');
         } catch (InvalidWebhookSignatureException $e) {
             $this->assertSame(SignatureFailureReason::MISSING_HASH, $e->getReason());
@@ -111,7 +112,7 @@ final class WebhookSignatureValidatorUnitTest extends TestCase
         $h = self::validHash();
         $tampered = substr($h, 0, -2) . (str_ends_with($h, '00') ? 'ff' : '00');
         try {
-            WebhookSignatureValidator::validate(self::buildHeader($tampered), self::REQUEST_ID, self::DATA_ID_LOWER, self::SECRET);
+            WebhookSignatureValidator::validate(self::buildHeader($tampered), self::REQUEST_ID, self::DATA_ID_RAW, self::SECRET);
             $this->fail('expected throw');
         } catch (InvalidWebhookSignatureException $e) {
             $this->assertSame(SignatureFailureReason::SIGNATURE_MISMATCH, $e->getReason());
@@ -122,12 +123,12 @@ final class WebhookSignatureValidatorUnitTest extends TestCase
     public function testOutsideToleranceThrows(): void
     {
         $staleTs = (string) ((int) (microtime(true) * 1000) - 30 * 60 * 1000);
-        $h = self::computeHash(self::DATA_ID_LOWER, self::REQUEST_ID, $staleTs, self::SECRET);
+        $h = self::computeHash(self::DATA_ID_RAW, self::REQUEST_ID, $staleTs, self::SECRET);
         try {
             WebhookSignatureValidator::validate(
                 self::buildHeader($h, $staleTs),
                 self::REQUEST_ID,
-                self::DATA_ID_LOWER,
+                self::DATA_ID_RAW,
                 self::SECRET,
                 300
             );
@@ -140,11 +141,11 @@ final class WebhookSignatureValidatorUnitTest extends TestCase
     public function testWithinTolerancePasses(): void
     {
         $current = (string) (int) (microtime(true) * 1000);
-        $h = self::computeHash(self::DATA_ID_LOWER, self::REQUEST_ID, $current, self::SECRET);
+        $h = self::computeHash(self::DATA_ID_RAW, self::REQUEST_ID, $current, self::SECRET);
         WebhookSignatureValidator::validate(
             self::buildHeader($h, $current),
             self::REQUEST_ID,
-            self::DATA_ID_LOWER,
+            self::DATA_ID_RAW,
             self::SECRET,
             300
         );
@@ -162,8 +163,8 @@ final class WebhookSignatureValidatorUnitTest extends TestCase
     // case 10
     public function testRequestIdAbsentExcludesRequestIdPair(): void
     {
-        $h = self::computeHash(self::DATA_ID_LOWER, null, self::TS, self::SECRET);
-        WebhookSignatureValidator::validate(self::buildHeader($h), null, self::DATA_ID_LOWER, self::SECRET);
+        $h = self::computeHash(self::DATA_ID_RAW, null, self::TS, self::SECRET);
+        WebhookSignatureValidator::validate(self::buildHeader($h), null, self::DATA_ID_RAW, self::SECRET);
         $this->assertTrue(true);
     }
 
@@ -187,7 +188,7 @@ final class WebhookSignatureValidatorUnitTest extends TestCase
     public function testSupportsV1WhenBothPresent(): void
     {
         $header = sprintf('ts=%s,v1=%s,v2=aaaa', self::TS, self::validHash());
-        WebhookSignatureValidator::validate($header, self::REQUEST_ID, self::DATA_ID_LOWER, self::SECRET);
+        WebhookSignatureValidator::validate($header, self::REQUEST_ID, self::DATA_ID_RAW, self::SECRET);
         $this->assertTrue(true);
     }
 
@@ -195,7 +196,7 @@ final class WebhookSignatureValidatorUnitTest extends TestCase
     {
         $header = sprintf('ts=%s,v2=somehash', self::TS);
         try {
-            WebhookSignatureValidator::validate($header, self::REQUEST_ID, self::DATA_ID_LOWER, self::SECRET);
+            WebhookSignatureValidator::validate($header, self::REQUEST_ID, self::DATA_ID_RAW, self::SECRET);
             $this->fail('expected throw');
         } catch (InvalidWebhookSignatureException $e) {
             $this->assertSame(SignatureFailureReason::MISSING_HASH, $e->getReason());
@@ -205,6 +206,6 @@ final class WebhookSignatureValidatorUnitTest extends TestCase
     public function testEmptySecretRaisesInvalidArgument(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        WebhookSignatureValidator::validate(self::buildHeader(self::validHash()), self::REQUEST_ID, self::DATA_ID_LOWER, '');
+        WebhookSignatureValidator::validate(self::buildHeader(self::validHash()), self::REQUEST_ID, self::DATA_ID_RAW, '');
     }
 }


### PR DESCRIPTION
---
  Summary
  
  - Preference metadata not mapped: The Serializer dropped any array field that had no class mapping (like metadata) because the fallthrough to property_exists was never
  reached when map() returned null. Fixed by adding a fallthrough branch guarded by a ReflectionProperty type check, so unmapped array fields are assigned directly as long as
  the declared property type accepts an array. Also added = null default to Preference::$metadata to prevent a fatal "must not be accessed before initialization" error when
  the API returns an empty {} object, which the serializer skips via !empty().
  - Webhook signature mismatch on uppercase data.id: The HMAC manifest builder was calling strtolower() on data.id before including it in the signed string. MercadoPago signs
  data.id in its original case, so any uppercase ID (e.g. ORD01JQ4S4KY8HWQ6NA5PXB65B3D3) would produce a SIGNATURE_MISMATCH on validation. Removed the strtolower() call so the
  locally computed manifest matches what the platform signs.

  Test plan

  - [ ] Run unit tests: vendor/bin/phpunit --testsuite "Unit Tests"
  - [ ] Verify $preference->metadata is populated with custom fields after create / get
  - [ ] Verify $preference->metadata is null (not a fatal error) when the API returns metadata: {}
  - [ ] Verify webhook validation passes for a data.id containing uppercase characters
