### PR TITLE
Release version 3.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 This project follows Keep a Changelog and Semantic Versioning.
 
+## [3.12.0] - 2026-06-27
+
+### Changed
+
+- Bump the SDK version to `3.12.0` in `MercadoPagoConfig::$CURRENT_VERSION`
+
 ## [3.11.0] - 2026-05-27
 
 ### Added

--- a/src/MercadoPago/MercadoPagoConfig.php
+++ b/src/MercadoPago/MercadoPagoConfig.php
@@ -22,7 +22,7 @@ use MercadoPago\Net\MPHttpClient;
 class MercadoPagoConfig
 {
     /** @var string Mercado Pago SDK version. */
-    public static string $CURRENT_VERSION = "3.11.3";
+    public static string $CURRENT_VERSION = "3.12.0";
 
     /** @var string Base URL for all API requests. Override only for testing or proxy scenarios. */
     public static string $BASE_URL = "https://api.mercadopago.com";


### PR DESCRIPTION
## Summary

- Bump `MercadoPagoConfig::$CURRENT_VERSION` from `3.11.3` to `3.12.0`
- Add `[3.12.0] - 2026-06-27` entry to `CHANGELOG.md`

## Test plan

- [ ] Verify `MercadoPagoConfig::$CURRENT_VERSION` returns `"3.12.0"`
- [ ] Confirm CHANGELOG entry is correctly formatted and dated

🤖 Generated with [Claude Code](https://claude.com/claude-code)