### PR TITLE
Fix path traversal vulnerability in string-ID client methods

### DIFF
--- a/src/MercadoPago/Client/Chargeback/ChargebackClient.php
+++ b/src/MercadoPago/Client/Chargeback/ChargebackClient.php
@@ -43,7 +43,7 @@ final class ChargebackClient extends MercadoPagoClient
      */
     public function get(string $id, ?RequestOptions $request_options = null): Chargeback
     {
-        $response = parent::send(sprintf(self::URL_WITH_ID, $id), HttpMethod::GET, null, null, $request_options);
+        $response = parent::send(sprintf(self::URL_WITH_ID, rawurlencode($id)), HttpMethod::GET, null, null, $request_options);
         $result = Serializer::deserializeFromJson(Chargeback::class, $response->getContent());
         $result->setResponse($response);
         return $result;

--- a/src/MercadoPago/Client/Customer/CustomerCardClient.php
+++ b/src/MercadoPago/Client/Customer/CustomerCardClient.php
@@ -44,7 +44,7 @@ final class CustomerCardClient extends MercadoPagoClient
      */
     public function create(string $customer_id, array $request, ?RequestOptions $request_options = null): CustomerCard
     {
-        $response = parent::send(sprintf(self::URL_CUSTOMER_ID, $customer_id), HttpMethod::POST, json_encode($request), null, $request_options);
+        $response = parent::send(sprintf(self::URL_CUSTOMER_ID, rawurlencode($customer_id)), HttpMethod::POST, json_encode($request), null, $request_options);
         $result = Serializer::deserializeFromJson(CustomerCard::class, $response->getContent());
         $result->setResponse($response);
         return $result;
@@ -63,7 +63,7 @@ final class CustomerCardClient extends MercadoPagoClient
      */
     public function get(string $customer_id, string $card_id, ?RequestOptions $request_options = null): CustomerCard
     {
-        $response = parent::send(sprintf(self::URL_CUSTOMER_ID_AND_CARD_ID, $customer_id, $card_id), HttpMethod::GET, null, null, $request_options);
+        $response = parent::send(sprintf(self::URL_CUSTOMER_ID_AND_CARD_ID, rawurlencode($customer_id), rawurlencode($card_id)), HttpMethod::GET, null, null, $request_options);
         $result = Serializer::deserializeFromJson(CustomerCard::class, $response->getContent());
         $result->setResponse($response);
         return $result;
@@ -82,7 +82,7 @@ final class CustomerCardClient extends MercadoPagoClient
      */
     public function update(string $customer_id, string $card_id, array $request, ?RequestOptions $request_options = null): CustomerCard
     {
-        $response = parent::send(sprintf(self::URL_CUSTOMER_ID_AND_CARD_ID, $customer_id, $card_id), HttpMethod::PUT, json_encode($request), null, $request_options);
+        $response = parent::send(sprintf(self::URL_CUSTOMER_ID_AND_CARD_ID, rawurlencode($customer_id), rawurlencode($card_id)), HttpMethod::PUT, json_encode($request), null, $request_options);
         $result = Serializer::deserializeFromJson(CustomerCard::class, $response->getContent());
         $result->setResponse($response);
         return $result;
@@ -101,7 +101,7 @@ final class CustomerCardClient extends MercadoPagoClient
      */
     public function delete(string $customer_id, string $card_id, ?RequestOptions $request_options = null): CustomerCard
     {
-        $response = parent::send(sprintf(self::URL_CUSTOMER_ID_AND_CARD_ID, $customer_id, $card_id), HttpMethod::DELETE, null, null, $request_options);
+        $response = parent::send(sprintf(self::URL_CUSTOMER_ID_AND_CARD_ID, rawurlencode($customer_id), rawurlencode($card_id)), HttpMethod::DELETE, null, null, $request_options);
         $result = Serializer::deserializeFromJson(CustomerCard::class, $response->getContent());
         $result->setResponse($response);
         return $result;
@@ -119,8 +119,8 @@ final class CustomerCardClient extends MercadoPagoClient
      */
     public function list(string $customer_id, ?RequestOptions $request_options = null): CustomerCardResult
     {
-        $response = parent::send(sprintf(self::URL_CUSTOMER_ID, $customer_id), HttpMethod::GET, null, null, $request_options);
-        $result_data = array("data" => $response->getContent());
+        $response = parent::send(sprintf(self::URL_CUSTOMER_ID, rawurlencode($customer_id)), HttpMethod::GET, null, null, $request_options);
+        $result_data = ["data" => $response->getContent()];
         $result = Serializer::deserializeFromJson(CustomerCardResult::class, $result_data);
         $result->setResponse($response);
         return $result;

--- a/src/MercadoPago/Client/Customer/CustomerClient.php
+++ b/src/MercadoPago/Client/Customer/CustomerClient.php
@@ -86,7 +86,7 @@ final class CustomerClient extends MercadoPagoClient
      */
     public function get(string $id, ?RequestOptions $request_options = null): Customer
     {
-        $response = parent::send(sprintf(self::URL_WITH_ID, $id), HttpMethod::GET, null, null, $request_options);
+        $response = parent::send(sprintf(self::URL_WITH_ID, rawurlencode($id)), HttpMethod::GET, null, null, $request_options);
         $result = Serializer::deserializeFromJson(Customer::class, $response->getContent());
         $result->setResponse($response);
         return $result;
@@ -105,7 +105,7 @@ final class CustomerClient extends MercadoPagoClient
      */
     public function update(string $id, array $request, ?RequestOptions $request_options = null): Customer
     {
-        $response = parent::send(sprintf(self::URL_WITH_ID, $id), HttpMethod::PUT, json_encode($request), null, $request_options);
+        $response = parent::send(sprintf(self::URL_WITH_ID, rawurlencode($id)), HttpMethod::PUT, json_encode($request), null, $request_options);
         $result = Serializer::deserializeFromJson(Customer::class, $response->getContent());
         $result->setResponse($response);
         return $result;

--- a/src/MercadoPago/Client/Order/OrderClient.php
+++ b/src/MercadoPago/Client/Order/OrderClient.php
@@ -70,7 +70,7 @@ final class OrderClient extends MercadoPagoClient
      */
     public function capture(string $order_id, ?RequestOptions $request_options = null): Order
     {
-        $response = parent::send(sprintf(self::URL_CAPTURE, $order_id), HttpMethod::POST, null, null, $request_options);
+        $response = parent::send(sprintf(self::URL_CAPTURE, rawurlencode($order_id)), HttpMethod::POST, null, null, $request_options);
         $result = Serializer::deserializeFromJson(Order::class, $response->getContent());
         $result->setResponse($response);
         return $result;
@@ -88,7 +88,7 @@ final class OrderClient extends MercadoPagoClient
      */
     public function get(string $order_id, ?RequestOptions $request_options = null): Order
     {
-        $response = parent::send(sprintf(self::URL_WITH_ID, $order_id), HttpMethod::GET, null, null, $request_options);
+        $response = parent::send(sprintf(self::URL_WITH_ID, rawurlencode($order_id)), HttpMethod::GET, null, null, $request_options);
         $result = Serializer::deserializeFromJson(Order::class, $response->getContent());
         $result->setResponse($response);
         return $result;
@@ -109,7 +109,7 @@ final class OrderClient extends MercadoPagoClient
      */
     public function cancel(string $order_id, ?RequestOptions $request_options = null): Order
     {
-        $response = parent::send(sprintf(self::URL_CANCEL, $order_id), HttpMethod::POST, null, null, $request_options);
+        $response = parent::send(sprintf(self::URL_CANCEL, rawurlencode($order_id)), HttpMethod::POST, null, null, $request_options);
         $result = Serializer::deserializeFromJson(Order::class, $response->getContent());
         $result->setResponse($response);
         return $result;
@@ -130,7 +130,7 @@ final class OrderClient extends MercadoPagoClient
      */
     public function process(string $order_id, ?RequestOptions $request_options = null): Order
     {
-        $response = parent::send(sprintf(self::URL_PROCESS, $order_id), HttpMethod::POST, null, null, $request_options);
+        $response = parent::send(sprintf(self::URL_PROCESS, rawurlencode($order_id)), HttpMethod::POST, null, null, $request_options);
         $result = Serializer::deserializeFromJson(Order::class, $response->getContent());
         $result->setResponse($response);
         return $result;
@@ -152,7 +152,7 @@ final class OrderClient extends MercadoPagoClient
      */
     public function refund(string $order_id, ?array $request = null, ?RequestOptions $request_options = null): Order
     {
-        $path = sprintf(self::URL_REFUND, $order_id);
+        $path = sprintf(self::URL_REFUND, rawurlencode($order_id));
         if ($request !== null) {
             $request = json_encode($request);
         }

--- a/src/MercadoPago/Client/Order/OrderTransactionClient.php
+++ b/src/MercadoPago/Client/Order/OrderTransactionClient.php
@@ -41,7 +41,7 @@ final class OrderTransactionClient extends MercadoPagoClient
      */
     public function create(string $order_id, array $request, ?RequestOptions $request_options = null): Transactions
     {
-        $path = sprintf(self::URL, $order_id);
+        $path = sprintf(self::URL, rawurlencode($order_id));
         $response = parent::send($path, HttpMethod::POST, json_encode($request), null, $request_options);
         $result = Serializer::deserializeFromJson(Transactions::class, $response->getContent());
         $result->setResponse($response);
@@ -61,7 +61,7 @@ final class OrderTransactionClient extends MercadoPagoClient
      */
     public function update(string $order_id, string $transaction_id, array $request, ?RequestOptions $request_options = null): UpdateTransaction
     {
-        $path = sprintf(self::URL_WITH_ID, $order_id, $transaction_id);
+        $path = sprintf(self::URL_WITH_ID, rawurlencode($order_id), rawurlencode($transaction_id));
         $response = parent::send($path, HttpMethod::PUT, json_encode($request), null, $request_options);
         $result = Serializer::deserializeFromJson(UpdateTransaction::class, $response->getContent());
         $result->setResponse($response);
@@ -80,7 +80,7 @@ final class OrderTransactionClient extends MercadoPagoClient
      */
     public function delete(string $order_id, string $transaction_id, ?RequestOptions $request_options = null): MPResponse
     {
-        $path = sprintf(self::URL_WITH_ID, $order_id, $transaction_id);
+        $path = sprintf(self::URL_WITH_ID, rawurlencode($order_id), rawurlencode($transaction_id));
         return parent::send($path, HttpMethod::DELETE, null, null, $request_options);
     }
 }

--- a/src/MercadoPago/Client/Point/PointClient.php
+++ b/src/MercadoPago/Client/Point/PointClient.php
@@ -58,7 +58,7 @@ final class PointClient extends MercadoPagoClient
      */
     public function createPaymentIntent(string $device_id, array $request, ?RequestOptions $request_options = null): PaymentIntent
     {
-        $response = parent::send(sprintf(self::PAYMENT_INTENT_URL, $device_id), HttpMethod::POST, json_encode($request), null, $request_options);
+        $response = parent::send(sprintf(self::PAYMENT_INTENT_URL, rawurlencode($device_id)), HttpMethod::POST, json_encode($request), null, $request_options);
         $result = Serializer::deserializeFromJson(PaymentIntent::class, $response->getContent());
         $result->setResponse($response);
         return $result;
@@ -75,7 +75,7 @@ final class PointClient extends MercadoPagoClient
      */
     public function searchPaymentIntent(string $payment_intent_id, ?RequestOptions $request_options = null): PaymentIntent
     {
-        $response = parent::send(sprintf(self::PAYMENT_INTENT_SEARCH_URL, $payment_intent_id), HttpMethod::GET, null, null, $request_options);
+        $response = parent::send(sprintf(self::PAYMENT_INTENT_SEARCH_URL, rawurlencode($payment_intent_id)), HttpMethod::GET, null, null, $request_options);
         $result = Serializer::deserializeFromJson(PaymentIntent::class, $response->getContent());
         $result->setResponse($response);
         return $result;
@@ -93,7 +93,7 @@ final class PointClient extends MercadoPagoClient
      */
     public function cancelPaymentIntent(string $device_id, string $payment_intent_id, ?RequestOptions $request_options = null): PaymentIntentCancel
     {
-        $response = parent::send(sprintf(self::PAYMENT_INTENT_DELETE_URL, $device_id, $payment_intent_id), HttpMethod::DELETE, null, null, $request_options);
+        $response = parent::send(sprintf(self::PAYMENT_INTENT_DELETE_URL, rawurlencode($device_id), rawurlencode($payment_intent_id)), HttpMethod::DELETE, null, null, $request_options);
         $result = Serializer::deserializeFromJson(PaymentIntentCancel::class, $response->getContent());
         $result->setResponse($response);
         return $result;
@@ -127,7 +127,7 @@ final class PointClient extends MercadoPagoClient
      */
     public function getPaymentIntentStatus(string $payment_intent_id, ?RequestOptions $request_options = null): PaymentIntentStatus
     {
-        $response = parent::send(sprintf(self::PAYMENT_INTENT_STATUS_URL, $payment_intent_id), HttpMethod::GET, null, null, $request_options);
+        $response = parent::send(sprintf(self::PAYMENT_INTENT_STATUS_URL, rawurlencode($payment_intent_id)), HttpMethod::GET, null, null, $request_options);
         $result = Serializer::deserializeFromJson(PaymentIntentStatus::class, $response->getContent());
         $result->setResponse($response);
         return $result;
@@ -163,7 +163,7 @@ final class PointClient extends MercadoPagoClient
      */
     public function changeDeviceOperatingMode(string $device_id, PointDeviceOperatingModeRequest $request, ?RequestOptions $request_options = null): PointDeviceOperatingMode
     {
-        $response = parent::send(sprintf(self::DEVICE_WITH_ID_URL, $device_id), HttpMethod::PATCH, json_encode($request), null, $request_options);
+        $response = parent::send(sprintf(self::DEVICE_WITH_ID_URL, rawurlencode($device_id)), HttpMethod::PATCH, json_encode($request), null, $request_options);
         $result = Serializer::deserializeFromJson(PointDeviceOperatingMode::class, $response->getContent());
         $result->setResponse($response);
         return $result;

--- a/src/MercadoPago/Client/PreApproval/PreApprovalClient.php
+++ b/src/MercadoPago/Client/PreApproval/PreApprovalClient.php
@@ -64,7 +64,7 @@ final class PreApprovalClient extends MercadoPagoClient
      */
     public function get(string $id, ?RequestOptions $request_options = null): PreApproval
     {
-        $response = parent::send(sprintf(self::URL_WITH_ID, $id), HttpMethod::GET, null, null, $request_options);
+        $response = parent::send(sprintf(self::URL_WITH_ID, rawurlencode($id)), HttpMethod::GET, null, null, $request_options);
         $result = Serializer::deserializeFromJson(PreApproval::class, $response->getContent());
         $result->setResponse($response);
         return $result;
@@ -82,7 +82,7 @@ final class PreApprovalClient extends MercadoPagoClient
      */
     public function update(string $id, array $request, ?RequestOptions $request_options = null): PreApproval
     {
-        $response = parent::send(sprintf(self::URL_WITH_ID, $id), HttpMethod::PUT, json_encode($request), null, $request_options);
+        $response = parent::send(sprintf(self::URL_WITH_ID, rawurlencode($id)), HttpMethod::PUT, json_encode($request), null, $request_options);
         $result = Serializer::deserializeFromJson(PreApproval::class, $response->getContent());
         $result->setResponse($response);
         return $result;

--- a/src/MercadoPago/Client/PreApprovalPlan/PreApprovalPlanClient.php
+++ b/src/MercadoPago/Client/PreApprovalPlan/PreApprovalPlanClient.php
@@ -60,7 +60,7 @@ final class PreApprovalPlanClient extends MercadoPagoClient
      */
     public function get(string $id, ?RequestOptions $request_options = null): PreApprovalPlan
     {
-        $response = parent::send(sprintf(self::URL_WITH_ID, $id), HttpMethod::GET, null, null, $request_options);
+        $response = parent::send(sprintf(self::URL_WITH_ID, rawurlencode($id)), HttpMethod::GET, null, null, $request_options);
         $result = Serializer::deserializeFromJson(PreApprovalPlan::class, $response->getContent());
         $result->setResponse($response);
         return $result;
@@ -78,7 +78,7 @@ final class PreApprovalPlanClient extends MercadoPagoClient
      */
     public function update(string $id, array $request, ?RequestOptions $request_options = null): PreApprovalPlan
     {
-        $response = parent::send(sprintf(self::URL_WITH_ID, $id), HttpMethod::PUT, json_encode($request), null, $request_options);
+        $response = parent::send(sprintf(self::URL_WITH_ID, rawurlencode($id)), HttpMethod::PUT, json_encode($request), null, $request_options);
         $result = Serializer::deserializeFromJson(PreApprovalPlan::class, $response->getContent());
         $result->setResponse($response);
         return $result;

--- a/src/MercadoPago/Client/Preference/PreferenceClient.php
+++ b/src/MercadoPago/Client/Preference/PreferenceClient.php
@@ -65,7 +65,7 @@ final class PreferenceClient extends MercadoPagoClient
      */
     public function get(string $id, ?RequestOptions $request_options = null): Preference
     {
-        $response = parent::send(sprintf(self::URL_WITH_ID, $id), HttpMethod::GET, null, null, $request_options);
+        $response = parent::send(sprintf(self::URL_WITH_ID, rawurlencode($id)), HttpMethod::GET, null, null, $request_options);
         $result = Serializer::deserializeFromJson(Preference::class, $response->getContent());
         $result->setResponse($response);
         return $result;
@@ -84,7 +84,7 @@ final class PreferenceClient extends MercadoPagoClient
      */
     public function update(string $id, array $request, ?RequestOptions $request_options = null): Preference
     {
-        $response = parent::send(sprintf(self::URL_WITH_ID, $id), HttpMethod::PUT, json_encode($request), null, $request_options);
+        $response = parent::send(sprintf(self::URL_WITH_ID, rawurlencode($id)), HttpMethod::PUT, json_encode($request), null, $request_options);
         $result = Serializer::deserializeFromJson(Preference::class, $response->getContent());
         $result->setResponse($response);
         return $result;


### PR DESCRIPTION
Apply rawurlencode() to all string ID parameters before sprintf() interpolation into API URL paths. Without encoding, a caller-supplied ID containing ../ sequences could traverse to unintended endpoints (e.g. ../../applications/<app_id>) and expose the merchant access token.

Affected clients: CustomerClient, CustomerCardClient, OrderClient, OrderTransactionClient, ChargebackClient, PreApprovalClient, PreApprovalPlanClient, PreferenceClient, PointClient (27 call sites).

Clients that use int IDs (PaymentClient, AdvancedPaymentClient, etc.) are not affected and left unchanged.