### PR TITLE
Add missing industry fields to Preference and Payment models

### DIFF
--- a/src/MercadoPago/Resources/Payment/AdditionalInfoPayer.php
+++ b/src/MercadoPago/Resources/Payment/AdditionalInfoPayer.php
@@ -30,9 +30,25 @@ class AdditionalInfoPayer
     /** ISO 8601 date when the payer registered on the integrator's platform. */
     public ?string $registration_date;
 
+    /** Authentication type used by the payer. */
+    public ?string $authentication_type;
+
+    /** Whether the payer is a prime user. */
+    public ?bool $is_prime_user;
+
+    /** Whether this is the payer's first online purchase. */
+    public ?bool $is_first_purchase_online;
+
+    /** ISO 8601 date of the payer's last purchase. */
+    public ?string $last_purchase;
+
+    /** @var \MercadoPago\Resources\Common\Identification|array|null Payer's identification document. */
+    public array|object|null $identification;
+
     private $map = [
         "phone" => "MercadoPago\Resources\Common\Phone",
-        "address" => "MercadoPago\Resources\Common\Address"
+        "address" => "MercadoPago\Resources\Common\Address",
+        "identification" => "MercadoPago\Resources\Common\Identification",
     ];
 
     /**

--- a/src/MercadoPago/Resources/Payment/Shipments.php
+++ b/src/MercadoPago/Resources/Payment/Shipments.php
@@ -18,8 +18,14 @@ class Shipments
     /** @var ReceiverAddress|array|null Delivery address where the purchased items will be shipped. */
     public array|object|null $receiver_address;
 
+    /** Whether the shipment uses express delivery. */
+    public ?bool $express_shipment;
+
+    /** Whether the buyer picks up the item locally. */
+    public ?bool $local_pickup;
+
     private $map = [
-        "receiver_address" => "MercadoPago\Resources\Payment\ReceiverAddress"
+        "receiver_address" => "MercadoPago\Resources\Payment\ReceiverAddress",
     ];
 
     /**

--- a/src/MercadoPago/Resources/Preference/CategoryDescriptor.php
+++ b/src/MercadoPago/Resources/Preference/CategoryDescriptor.php
@@ -2,20 +2,42 @@
 
 namespace MercadoPago\Resources\Preference;
 
+use MercadoPago\Serialization\Mapper;
+
 /**
  * Preference Category Descriptor resource.
  *
  * Provides additional category-specific metadata for a preference item, typically used
  * for travel or event-related purchases (e.g. passenger name, route, event date).
+ *
+ * Fields are mapped to typed DTOs:
+ * - passenger -> {@see \MercadoPago\Resources\Preference\Passenger}
+ * - route -> {@see \MercadoPago\Resources\Preference\Route}
  */
 class CategoryDescriptor
 {
+    /** Class mapper. */
+    use Mapper;
+
     /** Event date. */
     public ?string $event_date;
 
-    /** Passenger name. */
-    public ?string $passenger;
+    /** @var Passenger|array|null Passenger information. */
+    public array|object|null $passenger;
 
-    /** Route description. */
-    public ?string $route;
+    /** @var Route|array|null Route information. */
+    public array|object|null $route;
+
+    private $map = [
+        "passenger" => "MercadoPago\Resources\Preference\Passenger",
+        "route" => "MercadoPago\Resources\Preference\Route",
+    ];
+
+    /**
+     * Method responsible for getting map of entities.
+     */
+    public function getMap(): array
+    {
+        return $this->map;
+    }
 }

--- a/src/MercadoPago/Resources/Preference/Item.php
+++ b/src/MercadoPago/Resources/Preference/Item.php
@@ -40,6 +40,15 @@ class Item
     /** Category Descriptor */
     public array|object|null $category_descriptor;
 
+    /** Whether the item includes a warranty. */
+    public ?bool $warranty;
+
+    /** Item type. */
+    public ?string $type;
+
+    /** ISO 8601 date of the event associated with the item. */
+    public ?string $event_date;
+
     public $map = [
         "category_descriptor" => "MercadoPago\Resources\Preference\CategoryDescriptor",
     ];

--- a/src/MercadoPago/Resources/Preference/Passenger.php
+++ b/src/MercadoPago/Resources/Preference/Passenger.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace MercadoPago\Resources\Preference;
+
+use MercadoPago\Serialization\Mapper;
+
+/**
+ * Preference Passenger resource.
+ *
+ * Represents a passenger associated with a travel-related preference item.
+ *
+ * Fields are mapped to common DTOs:
+ * - identification -> {@see \MercadoPago\Resources\Common\Identification}
+ */
+class Passenger
+{
+    /** Class mapper. */
+    use Mapper;
+
+    /** Passenger's first name. */
+    public ?string $first_name;
+
+    /** Passenger's last name. */
+    public ?string $last_name;
+
+    /** @var \MercadoPago\Resources\Common\Identification|array|null Passenger's identification document. */
+    public array|object|null $identification;
+
+    private $map = [
+        "identification" => "MercadoPago\Resources\Common\Identification",
+    ];
+
+    /**
+     * Method responsible for getting map of entities.
+     */
+    public function getMap(): array
+    {
+        return $this->map;
+    }
+}

--- a/src/MercadoPago/Resources/Preference/Payer.php
+++ b/src/MercadoPago/Resources/Preference/Payer.php
@@ -45,6 +45,18 @@ class Payer
     /** Date of the last purchase. */
     public ?string $last_purchase;
 
+    /** Authentication type used by the payer. */
+    public ?string $authentication_type;
+
+    /** Whether the payer is a prime user. */
+    public ?bool $is_prime_user;
+
+    /** Whether this is the payer's first online purchase. */
+    public ?bool $is_first_purchase_online;
+
+    /** ISO 8601 date when the payer registered. */
+    public ?string $registration_date;
+
     private $map = [
         "identification" => "MercadoPago\Resources\Common\Identification",
         "phone" => "MercadoPago\Resources\Common\Phone",

--- a/src/MercadoPago/Resources/Preference/Route.php
+++ b/src/MercadoPago/Resources/Preference/Route.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace MercadoPago\Resources\Preference;
+
+/**
+ * Preference Route resource.
+ *
+ * Represents a travel route associated with a travel-related preference item.
+ */
+class Route
+{
+    /** Departure location. */
+    public ?string $departure;
+
+    /** Destination location. */
+    public ?string $destination;
+
+    /** ISO 8601 date and time of departure. */
+    public ?string $departure_date_time;
+
+    /** ISO 8601 date and time of arrival. */
+    public ?string $arrival_date_time;
+
+    /** Carrier or company name. */
+    public ?string $company;
+}


### PR DESCRIPTION
- Preference\Payer: authentication_type, is_prime_user, is_first_purchase_online, registration_date
- Preference\Item: warranty, type, event_date
- Preference\CategoryDescriptor: refactor passenger and route from plain strings to typed Passenger and Route objects
- New Preference\Passenger: first_name, last_name, identification
- New Preference\Route: departure, destination, departure_date_time, arrival_date_time, company
- Payment\AdditionalInfoPayer: authentication_type, is_prime_user, is_first_purchase_online, last_purchase, identification
- Payment\Shipments: express_shipment, local_pickup