### PR TITLE
Fix Card expiration type and revert PHP minimum version to 8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     },
     "require": {
-        "php": ">=8.5"
+        "php": ">=8.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.0",

--- a/src/MercadoPago/Resources/Payment/Card.php
+++ b/src/MercadoPago/Resources/Payment/Card.php
@@ -25,10 +25,10 @@ class Card
     public ?string $first_six_digits;
 
     /** Four-digit expiration year of the card. */
-    public ?int $expiration_year;
+    public int|string|null $expiration_year;
 
     /** Two-digit expiration month of the card (1-12). */
-    public ?int $expiration_month;
+    public int|string|null $expiration_month;
 
     /** ISO 8601 timestamp when the card record was created. */
     public ?string $date_created;


### PR DESCRIPTION
## Summary

- **Card expiration masking**: `Card::$expiration_month` and `Card::$expiration_year`
  now accept `int|string|null` instead of `?int`. The MercadoPago API recently started
  returning `"***"` for these fields when masked, causing a `TypeError` in the
  Serializer for users calling `PaymentClient::get()`.

- **PHP version constraint**: Reverts `composer.json` from `>=8.5` back to `>=8.2`.
  The bump was accidentally introduced in a dependency update with no technical
  justification — no PHP 8.5-exclusive features are used in the SDK. This was blocking
  all users on PHP 8.2/8.3/8.4 from installing v3.12.0.