### PR TITLE
Bump version to 3.12.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ First time using Mercado Pago? Create your [Mercado Pago account](https://www.me
 2. Install PHP SDK for MercadoPago running in command line:
 
 ```
-composer require "mercadopago/dx-php:3.12.0"
+composer require "mercadopago/dx-php:3.12.1"
 ```
 
 > You can also run _composer require "mercadopago/dx-php:2.6.2"_ for PHP7.1 or _composer require "mercadopago/dx-php:1.12.6"_ for PHP5.6.

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "mercadopago/dx-php",
     "description": "Mercado Pago PHP SDK",
-    "version": "3.12.0",
+    "version": "3.12.1",
     "type": "library",
     "license": "MIT",
     "homepage": "https://github.com/mercadopago/sdk-php",

--- a/src/MercadoPago/MercadoPagoConfig.php
+++ b/src/MercadoPago/MercadoPagoConfig.php
@@ -22,7 +22,7 @@ use MercadoPago\Net\MPHttpClient;
 class MercadoPagoConfig
 {
     /** @var string Mercado Pago SDK version. */
-    public static string $CURRENT_VERSION = "3.12.0";
+    public static string $CURRENT_VERSION = "3.12.1";
 
     /** @var string Base URL for all API requests. Override only for testing or proxy scenarios. */
     public static string $BASE_URL = "https://api.mercadopago.com";


### PR DESCRIPTION
## Summary
- Bump patch version from 3.12.0 to 3.12.1

## Files changed
- `composer.json` — version updated to 3.12.1
- `src/MercadoPago/MercadoPagoConfig.php` — `$CURRENT_VERSION` updated to 3.12.1
- `README.md` — composer require reference updated to 3.12.1

## Test plan
- [ ] Verify CI passes
- [ ] Confirm version string is correct in all files