### PR TITLE
Pin GitHub Actions to SHA for supply chain security

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: '8.5'
 


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions to full SHA commit hashes to prevent supply chain attacks via mutable tags

## Changes
- `ci-master.yml`: `actions/checkout@v7` → `@9c091bb2...`, `shivammathur/setup-php@v2` → `@f3e473d1...`

## Test plan
- [ ] CI passes on this PR