### PR TITLE
Add CREDENTIAL_ON_FILE messaging fields to Payment resource

### DIFF
--- a/src/MercadoPago/Resources/Payment/TransactionData.php
+++ b/src/MercadoPago/Resources/Payment/TransactionData.php
@@ -39,8 +39,21 @@ class TransactionData
     /** End-to-end identifier for Pix transactions, used for reconciliation. */
     public ?string $e2e_id;
 
+    /** Indicates whether this is the first transaction in a CREDENTIAL_ON_FILE agreement. */
+    public ?bool $first_transaction;
+
+    /** Storage type for the credential-on-file agreement (e.g. "ON_DEMAND", "RECURRING"). */
+    public ?string $storage;
+
+    /** Initiator of the transaction in a CREDENTIAL_ON_FILE flow (e.g. "MERCHANT", "CUSTOMER"). */
+    public ?string $transaction_initiator;
+
+    /** @var TransactionDataReference|array|null Reference to the original stored-credential transaction. */
+    public array|object|null $reference;
+
     private $map = [
         "bank_info" => "MercadoPago\Resources\Payment\BankInfo",
+        "reference" => "MercadoPago\Resources\Payment\TransactionDataReference",
     ];
 
     /**

--- a/src/MercadoPago/Resources/Payment/TransactionDataReference.php
+++ b/src/MercadoPago/Resources/Payment/TransactionDataReference.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace MercadoPago\Resources\Payment;
+
+/**
+ * Represents the reference data associated with a CREDENTIAL_ON_FILE transaction in the MercadoPago API.
+ *
+ * Contains identifiers that link the current transaction to a prior agreement or
+ * stored credential. Nested within {@see TransactionData}.
+ */
+class TransactionDataReference
+{
+    /** Identifier of the original transaction used as the stored credential reference. */
+    public ?string $id;
+}


### PR DESCRIPTION
## Summary

- Adds four new deserialization properties to \`TransactionData\` to expose the fields returned by the API for the \`CREDENTIAL_ON_FILE\` messaging flow (formerly \`SUBSCRIPTIONS\`):
  - \`first_transaction\` (\`?bool\`): indicates whether this is the first transaction under the stored-credential agreement
  - \`storage\` (\`?string\`): credential storage type (e.g. \`ON_DEMAND\`, \`RECURRING\`)
  - \`transaction_initiator\` (\`?string\`): who initiated the transaction (\`MERCHANT\` or \`CUSTOMER\`)
  - \`reference\` (\`TransactionDataReference|array|null\`): links back to the original agreement transaction via its \`id\`
- Creates \`TransactionDataReference\` as a new nested DTO class, following the same pattern used by \`BankInfo\` and other \`Payment\` sub-resources
- No request-layer changes: the PHP SDK uses pass-through arrays, so no new request classes are needed
- \`PointOfInteraction::\$sub_type\` was verified as already present — no change required there

## Test plan

- [ ] Verify \`TransactionData\` can be deserialized from an API response that includes \`first_transaction\`, \`storage\`, \`transaction_initiator\`, and \`reference.id\`
- [ ] Confirm \`reference\` is mapped to a \`TransactionDataReference\` instance (not a plain array) via the \`Mapper\` trait
- [ ] Run existing unit test suite: \`vendor/bin/phpunit --testsuite "Unit Tests"\`
- [ ] Run pre-commit checks: \`pre-commit run --all-files\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)