### PR TITLE
Feature/ergonomia sdk

### DIFF
--- a/src/MercadoPago/Client/Common/RequestOptions.php
+++ b/src/MercadoPago/Client/Common/RequestOptions.php
@@ -17,6 +17,36 @@ namespace MercadoPago\Client\Common;
  */
 class RequestOptions
 {
+    /** Default maximum number of retry attempts for retryable status codes. */
+    const DEFAULT_MAX_RETRIES = 3;
+
+    /** Default connection timeout in milliseconds (60 seconds). */
+    const DEFAULT_TIMEOUT_MS = 60000;
+
+    /** Default maximum delay between retries in milliseconds (30 seconds). */
+    const DEFAULT_MAX_DELAY_MS = 30000;
+
+    /** Default HTTP status codes that trigger a retry. */
+    const DEFAULT_RETRY_ON = [429, 500, 502, 503, 504];
+
+    /** @var int|null Maximum retries; null = use MercadoPagoConfig global. */
+    private ?int $max_retries = null;
+
+    /** @var array<int>|null Status codes to retry; null = DEFAULT_RETRY_ON. */
+    private ?array $retry_on = null;
+
+    /** @var int|null Initial backoff delay in ms; null = no extra delay. */
+    private ?int $initial_delay_ms = null;
+
+    /** @var int|null Max backoff delay in ms; null = DEFAULT_MAX_DELAY_MS. */
+    private ?int $max_delay_ms = null;
+
+    /** @var bool|null Add random jitter to delay. */
+    private ?bool $jitter = null;
+
+    /** @var callable|null Callback(int $attempt, \Throwable $error): void invoked before each retry. */
+    private $on_retry = null;
+
     /**
      * @param string|null $access_token     OAuth Bearer token override. Falls back to {@see \MercadoPago\MercadoPagoConfig::getAccessToken()}.
      * @param int|null    $connection_timeout Timeout in milliseconds override. Falls back to global config.
@@ -72,4 +102,62 @@ class RequestOptions
     {
         $this->custom_headers = $custom_headers;
     }
+
+    public function getMaxRetries(): ?int { return $this->max_retries; }
+
+    /** @throws \InvalidArgumentException if $v is negative */
+    public function setMaxRetries(int $v): void
+    {
+        if ($v < 0) {
+            throw new \InvalidArgumentException("max_retries must be >= 0, got: $v");
+        }
+        $this->max_retries = $v;
+    }
+
+    /** @return array<int>|null */
+    public function getRetryOn(): ?array { return $this->retry_on; }
+
+    /** @param array<int> $codes
+     * @throws \InvalidArgumentException if any code is outside 100-599 */
+    public function setRetryOn(array $codes): void
+    {
+        foreach ($codes as $code) {
+            if ($code < 100 || $code > 599) {
+                throw new \InvalidArgumentException("Invalid HTTP status code in retry_on: $code");
+            }
+        }
+        $this->retry_on = $codes;
+    }
+
+    public function getInitialDelayMs(): ?int { return $this->initial_delay_ms; }
+
+    /** @throws \InvalidArgumentException if $v is negative */
+    public function setInitialDelayMs(int $v): void
+    {
+        if ($v < 0) {
+            throw new \InvalidArgumentException("initial_delay_ms must be >= 0, got: $v");
+        }
+        $this->initial_delay_ms = $v;
+    }
+
+    public function getMaxDelayMs(): ?int { return $this->max_delay_ms; }
+
+    /** @throws \InvalidArgumentException if $v is negative */
+    public function setMaxDelayMs(int $v): void
+    {
+        if ($v < 0) {
+            throw new \InvalidArgumentException("max_delay_ms must be >= 0, got: $v");
+        }
+        $this->max_delay_ms = $v;
+    }
+
+    public function getJitter(): ?bool { return $this->jitter; }
+
+    public function setJitter(bool $v): void { $this->jitter = $v; }
+
+    /** @return callable|null */
+    public function getOnRetry() { return $this->on_retry; }
+
+    /** @param callable $callback function(int $attempt, \Throwable $error): void */
+    public function setOnRetry(callable $callback): void { $this->on_retry = $callback; }
 }

--- a/src/MercadoPago/Client/Customer/CustomerClient.php
+++ b/src/MercadoPago/Client/Customer/CustomerClient.php
@@ -7,6 +7,7 @@ use MercadoPago\Client\MercadoPagoClient;
 use MercadoPago\MercadoPagoConfig;
 use MercadoPago\Net\HttpMethod;
 use MercadoPago\Net\MPHttpClient;
+use MercadoPago\Net\MPAutoPaginationGenerator;
 use MercadoPago\Net\MPSearchRequest;
 use MercadoPago\Resources\Customer;
 use MercadoPago\Resources\CustomerSearch;
@@ -128,5 +129,22 @@ final class CustomerClient extends MercadoPagoClient
         $result = Serializer::deserializeFromJson(CustomerSearch::class, $response->getContent());
         $result->setResponse($response);
         return $result;
+    }
+
+    /**
+     * Returns a Generator that lazily fetches all pages of customers matching the search criteria.
+     *
+     * @param MPSearchRequest|null $request Search filters and pagination seed.
+     * @param RequestOptions|null $request_options Per-request overrides.
+     * @return \Generator Yields individual Customer items.
+     */
+    public function searchAll(?MPSearchRequest $request = null, ?RequestOptions $request_options = null): \Generator
+    {
+        $request = $request ?? new MPSearchRequest(100, 0);
+        return MPAutoPaginationGenerator::of(
+            fn($req, $opts) => $this->search($req, $opts),
+            $request,
+            $request_options
+        );
     }
 }

--- a/src/MercadoPago/Client/MercadoPagoClient.php
+++ b/src/MercadoPago/Client/MercadoPagoClient.php
@@ -55,7 +55,16 @@ class MercadoPagoClient
         ?RequestOptions $request_options = null
     ): MPRequest {
         $path = $this->formatUrlWithQueryParams($path, $query_params);
-        return new MPRequest($path, $method, $payload, $this->addHeaders($method, $request_options), $this->addConnectionTimeout($request_options));
+        $request = new MPRequest($path, $method, $payload, $this->addHeaders($method, $request_options), $this->addConnectionTimeout($request_options));
+        if ($request_options !== null) {
+            $request->setMaxRetries($request_options->getMaxRetries());
+            $request->setRetryOn($request_options->getRetryOn());
+            $request->setInitialDelayMs($request_options->getInitialDelayMs());
+            $request->setMaxDelayMs($request_options->getMaxDelayMs());
+            $request->setJitter($request_options->getJitter());
+            $request->setOnRetry($request_options->getOnRetry());
+        }
+        return $request;
     }
 
     private function formatUrlWithQueryParams(string $url, ?array $query_params): string

--- a/src/MercadoPago/Client/Payment/PaymentClient.php
+++ b/src/MercadoPago/Client/Payment/PaymentClient.php
@@ -7,6 +7,7 @@ use MercadoPago\Client\MercadoPagoClient;
 use MercadoPago\MercadoPagoConfig;
 use MercadoPago\Net\HttpMethod;
 use MercadoPago\Net\MPHttpClient;
+use MercadoPago\Net\MPAutoPaginationGenerator;
 use MercadoPago\Net\MPSearchRequest;
 use MercadoPago\Resources\Payment;
 use MercadoPago\Resources\PaymentSearch;
@@ -131,5 +132,21 @@ final class PaymentClient extends MercadoPagoClient
         $result = Serializer::deserializeFromJson(PaymentSearch::class, $response->getContent());
         $result->setResponse($response);
         return $result;
+    }
+
+    /**
+     * Returns a Generator that lazily fetches all pages of payments matching the search criteria.
+     *
+     * @param MPSearchRequest $request Search filters and pagination seed.
+     * @param RequestOptions|null $request_options Per-request overrides.
+     * @return \Generator Yields individual PaymentSearchResult items.
+     */
+    public function searchAll(MPSearchRequest $request, ?RequestOptions $request_options = null): \Generator
+    {
+        return MPAutoPaginationGenerator::of(
+            fn($req, $opts) => $this->search($req, $opts),
+            $request,
+            $request_options
+        );
     }
 }

--- a/src/MercadoPago/Client/PreApproval/PreApprovalClient.php
+++ b/src/MercadoPago/Client/PreApproval/PreApprovalClient.php
@@ -7,6 +7,7 @@ use MercadoPago\Client\MercadoPagoClient;
 use MercadoPago\MercadoPagoConfig;
 use MercadoPago\Net\HttpMethod;
 use MercadoPago\Net\MPHttpClient;
+use MercadoPago\Net\MPAutoPaginationGenerator;
 use MercadoPago\Net\MPSearchRequest;
 use MercadoPago\Resources\PreApproval;
 use MercadoPago\Resources\PreApprovalSearch;
@@ -105,5 +106,21 @@ final class PreApprovalClient extends MercadoPagoClient
         $result = Serializer::deserializeFromJson(PreApprovalSearch::class, $response->getContent());
         $result->setResponse($response);
         return $result;
+    }
+
+    /**
+     * Returns a Generator that lazily fetches all pages of pre-approvals matching the search criteria.
+     *
+     * @param MPSearchRequest $request Search filters and pagination seed.
+     * @param RequestOptions|null $request_options Per-request overrides.
+     * @return \Generator Yields individual PreApproval items.
+     */
+    public function searchAll(MPSearchRequest $request, ?RequestOptions $request_options = null): \Generator
+    {
+        return MPAutoPaginationGenerator::of(
+            fn($req, $opts) => $this->search($req, $opts),
+            $request,
+            $request_options
+        );
     }
 }

--- a/src/MercadoPago/Exceptions/MPAuthenticationException.php
+++ b/src/MercadoPago/Exceptions/MPAuthenticationException.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace MercadoPago\Exceptions;
+
+/** Thrown when the API returns HTTP 401 Unauthorized (missing or invalid credentials). */
+class MPAuthenticationException extends MPApiException {}

--- a/src/MercadoPago/Exceptions/MPBadRequestException.php
+++ b/src/MercadoPago/Exceptions/MPBadRequestException.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace MercadoPago\Exceptions;
+
+/** Thrown when the API returns HTTP 400 Bad Request (validation or syntax error). */
+class MPBadRequestException extends MPApiException {}

--- a/src/MercadoPago/Exceptions/MPConnectionException.php
+++ b/src/MercadoPago/Exceptions/MPConnectionException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace MercadoPago\Exceptions;
+
+use Exception;
+
+/** Thrown when a transport-level or network error occurs (timeout, DNS failure, SSL error). */
+class MPConnectionException extends Exception {}

--- a/src/MercadoPago/Exceptions/MPDependencyException.php
+++ b/src/MercadoPago/Exceptions/MPDependencyException.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace MercadoPago\Exceptions;
+
+/** Thrown when the API returns HTTP 424 Failed Dependency (internal dependency failure — retryable). */
+class MPDependencyException extends MPApiException {}

--- a/src/MercadoPago/Exceptions/MPForbiddenException.php
+++ b/src/MercadoPago/Exceptions/MPForbiddenException.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace MercadoPago\Exceptions;
+
+/** Thrown when the API returns HTTP 403 Forbidden. */
+class MPForbiddenException extends MPApiException {}

--- a/src/MercadoPago/Exceptions/MPIdempotencyException.php
+++ b/src/MercadoPago/Exceptions/MPIdempotencyException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace MercadoPago\Exceptions;
+
+/**
+ * Thrown when the API returns HTTP 409 Conflict.
+ * Covers both idempotency-key conflicts and state-machine conflicts (e.g. cannot_refund_order).
+ */
+class MPIdempotencyException extends MPApiException {}

--- a/src/MercadoPago/Exceptions/MPNotFoundException.php
+++ b/src/MercadoPago/Exceptions/MPNotFoundException.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace MercadoPago\Exceptions;
+
+/** Thrown when the API returns HTTP 404 Not Found. */
+class MPNotFoundException extends MPApiException {}

--- a/src/MercadoPago/Exceptions/MPPaymentException.php
+++ b/src/MercadoPago/Exceptions/MPPaymentException.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace MercadoPago\Exceptions;
+
+/** Thrown when the API returns HTTP 402 Payment Required (transaction processing error, e.g. Orders/AP). */
+class MPPaymentException extends MPApiException {}

--- a/src/MercadoPago/Exceptions/MPRateLimitException.php
+++ b/src/MercadoPago/Exceptions/MPRateLimitException.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace MercadoPago\Exceptions;
+
+use MercadoPago\Net\MPResponse;
+
+/**
+ * Thrown when the API returns HTTP 429 Too Many Requests.
+ * Exposes the Retry-After header value (in seconds) when present.
+ */
+class MPRateLimitException extends MPApiException
+{
+    private ?int $retry_after;
+
+    public function __construct(string $message, MPResponse $response, ?int $retry_after = null)
+    {
+        parent::__construct($message, $response);
+        $this->retry_after = $retry_after;
+    }
+
+    /** Returns seconds to wait before retrying, or null if the Retry-After header was absent. */
+    public function getRetryAfter(): ?int
+    {
+        return $this->retry_after;
+    }
+}

--- a/src/MercadoPago/Exceptions/MPResourceLockedException.php
+++ b/src/MercadoPago/Exceptions/MPResourceLockedException.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace MercadoPago\Exceptions;
+
+/** Thrown when the API returns HTTP 423 Locked (idempotency key temporarily locked — retryable). */
+class MPResourceLockedException extends MPApiException {}

--- a/src/MercadoPago/Exceptions/MPServerException.php
+++ b/src/MercadoPago/Exceptions/MPServerException.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace MercadoPago\Exceptions;
+
+/** Thrown when the API returns HTTP 5xx Server Error. */
+class MPServerException extends MPApiException {}

--- a/src/MercadoPago/Exceptions/MPValidationException.php
+++ b/src/MercadoPago/Exceptions/MPValidationException.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace MercadoPago\Exceptions;
+
+/** Thrown when the API returns HTTP 422 Unprocessable Entity (business rule violation). */
+class MPValidationException extends MPApiException {}

--- a/src/MercadoPago/Net/MPAutoPaginationGenerator.php
+++ b/src/MercadoPago/Net/MPAutoPaginationGenerator.php
@@ -12,6 +12,11 @@ use MercadoPago\Client\Common\RequestOptions;
  * API response. Pages are fetched on demand; iteration stops when results are empty
  * or the offset reaches the total.
  *
+ * Supports different response key conventions used across MercadoPago APIs:
+ * - "results"  → payments, customers, preapprovals, preferences, etc.
+ * - "data"     → Orders v2 API (also uses string paging values like "181")
+ * - "elements" → some Order patterns (Pattern B)
+ *
  * Example:
  * ```php
  * $request = new MPSearchRequest(100, 0);
@@ -28,36 +33,42 @@ class MPAutoPaginationGenerator
      * Creates a Generator that lazily fetches all pages.
      *
      * @param callable $searchFn function(MPSearchRequest $req, ?RequestOptions $opts): object
-     *        The callable must return an object with a public $results array and
-     *        a public $paging object having a $total property.
+     *        The callable must return an object with a results/data/elements array and
+     *        a paging object having a total property (int or string).
      * @param MPSearchRequest $request Initial search parameters.
      * @param RequestOptions|null $options Per-request overrides.
      * @return Generator<mixed> Yields individual items from each page.
      */
     public static function of(callable $searchFn, MPSearchRequest $request, ?RequestOptions $options = null): Generator
     {
-        $limit = ($request->getLimit() !== null && $request->getLimit() > 0)
+        $limit  = ($request->getLimit() !== null && $request->getLimit() > 0)
             ? $request->getLimit()
             : self::DEFAULT_PAGE_SIZE;
         $offset = $request->getOffset() ?? 0;
 
         while (true) {
             $pageRequest = new MPSearchRequest($limit, $offset, $request->getFilters());
-            $page = $searchFn($pageRequest, $options);
+            $page        = $searchFn($pageRequest, $options);
 
-            $results = $page->results ?? [];
-            if (empty($results)) {
+            // Support different response key conventions:
+            // - "results"  → payments, customers, preapprovals, etc.
+            // - "data"     → Orders v2 API
+            // - "elements" → some Order patterns (Pattern B)
+            $items = $page->results ?? $page->data ?? $page->elements ?? null;
+
+            if (empty($items)) {
                 return;
             }
 
-            foreach ($results as $item) {
+            foreach ($items as $item) {
                 yield $item;
             }
 
-            $total = $page->paging?->total ?? 0;
-            $offset += count($results);
+            // paging.total may be int (payments) or string (Orders v2 → "181")
+            $total  = isset($page->paging->total) ? (int) $page->paging->total : 0;
+            $offset += count($items);
 
-            if ($offset >= $total) {
+            if ($total > 0 && $offset >= $total) {
                 return;
             }
         }

--- a/src/MercadoPago/Net/MPAutoPaginationGenerator.php
+++ b/src/MercadoPago/Net/MPAutoPaginationGenerator.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace MercadoPago\Net;
+
+use Generator;
+use MercadoPago\Client\Common\RequestOptions;
+
+/**
+ * Creates a lazy PHP Generator that automatically fetches all pages of search results.
+ *
+ * Each call to {@see of()} returns a Generator that yields individual items from the
+ * API response. Pages are fetched on demand; iteration stops when results are empty
+ * or the offset reaches the total.
+ *
+ * Example:
+ * ```php
+ * $request = new MPSearchRequest(100, 0);
+ * foreach ($paymentClient->searchAll($request) as $payment) {
+ *     process($payment);
+ * }
+ * ```
+ */
+class MPAutoPaginationGenerator
+{
+    private const DEFAULT_PAGE_SIZE = 100;
+
+    /**
+     * Creates a Generator that lazily fetches all pages.
+     *
+     * @param callable $searchFn function(MPSearchRequest $req, ?RequestOptions $opts): object
+     *        The callable must return an object with a public $results array and
+     *        a public $paging object having a $total property.
+     * @param MPSearchRequest $request Initial search parameters.
+     * @param RequestOptions|null $options Per-request overrides.
+     * @return Generator<mixed> Yields individual items from each page.
+     */
+    public static function of(callable $searchFn, MPSearchRequest $request, ?RequestOptions $options = null): Generator
+    {
+        $limit = ($request->getLimit() !== null && $request->getLimit() > 0)
+            ? $request->getLimit()
+            : self::DEFAULT_PAGE_SIZE;
+        $offset = $request->getOffset() ?? 0;
+
+        while (true) {
+            $pageRequest = new MPSearchRequest($limit, $offset, $request->getFilters());
+            $page = $searchFn($pageRequest, $options);
+
+            $results = $page->results ?? [];
+            if (empty($results)) {
+                return;
+            }
+
+            foreach ($results as $item) {
+                yield $item;
+            }
+
+            $total = $page->paging?->total ?? 0;
+            $offset += count($results);
+
+            if ($offset >= $total) {
+                return;
+            }
+        }
+    }
+}

--- a/src/MercadoPago/Net/MPDefaultHttpClient.php
+++ b/src/MercadoPago/Net/MPDefaultHttpClient.php
@@ -3,7 +3,20 @@
 namespace MercadoPago\Net;
 
 use Exception;
+use MercadoPago\Client\Common\RequestOptions;
 use MercadoPago\Exceptions\MPApiException;
+use MercadoPago\Exceptions\MPAuthenticationException;
+use MercadoPago\Exceptions\MPBadRequestException;
+use MercadoPago\Exceptions\MPConnectionException;
+use MercadoPago\Exceptions\MPDependencyException;
+use MercadoPago\Exceptions\MPForbiddenException;
+use MercadoPago\Exceptions\MPIdempotencyException;
+use MercadoPago\Exceptions\MPNotFoundException;
+use MercadoPago\Exceptions\MPPaymentException;
+use MercadoPago\Exceptions\MPRateLimitException;
+use MercadoPago\Exceptions\MPResourceLockedException;
+use MercadoPago\Exceptions\MPServerException;
+use MercadoPago\Exceptions\MPValidationException;
 use MercadoPago\MercadoPagoConfig;
 
 /**
@@ -21,6 +34,8 @@ class MPDefaultHttpClient implements MPHttpClient
 {
     /** Microseconds per millisecond, used to convert retry delay to usleep units. */
     private const ONE_MILLISECOND = 1000;
+
+    private const RETRY_AFTER_HEADER = 'Retry-After';
 
     private HttpRequest $httpRequest;
 
@@ -45,27 +60,49 @@ class MPDefaultHttpClient implements MPHttpClient
      */
     public function send(MPRequest $request): MPResponse
     {
-        $max_retries = MercadoPagoConfig::getMaxRetries();
+        $max_retries = $request->getMaxRetries() ?? MercadoPagoConfig::getMaxRetries();
+        $retry_on    = $request->getRetryOn()    ?? RequestOptions::DEFAULT_RETRY_ON;
+        $initial_ms  = $request->getInitialDelayMs() ?? (MercadoPagoConfig::getRetryDelay() ?: 200);
+        $max_ms      = $request->getMaxDelayMs()     ?? RequestOptions::DEFAULT_MAX_DELAY_MS;
+        $use_jitter  = $request->getJitter()         ?? false;
+        $on_retry    = $request->getOnRetry();
 
-        for ($retry_count = 0; $retry_count <= $max_retries; $retry_count++) {
+        $last_exception = null;
+
+        for ($attempt = 0; $attempt <= $max_retries; $attempt++) {
             try {
                 return $this->makeRequest($request);
             } catch (MPApiException $e) {
                 $status_code = $e->getApiResponse()->getStatusCode();
-                if ($this->isServerError($status_code) && !$this->isLastRetry($retry_count)) {
-                    $this->doExponentialBackoff($retry_count);
+                if ($attempt < $max_retries && in_array($status_code, $retry_on, true)) {
+                    $last_exception = $e;
+                    if ($on_retry !== null) {
+                        ($on_retry)($attempt + 1, $e);
+                    }
+                    $this->sleepMicroseconds(
+                        $this->computeDelayMicroseconds($attempt, $initial_ms, $max_ms, $use_jitter)
+                    );
                 } else {
                     throw $e;
                 }
             } catch (Exception $e) {
-                if (!$this->isLastRetry($retry_count)) {
-                    $this->doExponentialBackoff($retry_count);
+                if ($attempt < $max_retries) {
+                    $last_exception = $e;
+                    if ($on_retry !== null) {
+                        ($on_retry)($attempt + 1, $e);
+                    }
+                    $this->sleepMicroseconds(
+                        $this->computeDelayMicroseconds($attempt, $initial_ms, $max_ms, $use_jitter)
+                    );
                 } else {
                     throw $e;
                 }
             }
         }
 
+        if ($last_exception !== null) {
+            throw $last_exception;
+        }
         throw new Exception("Error processing request. Please try again.");
     }
 
@@ -85,18 +122,47 @@ class MPDefaultHttpClient implements MPHttpClient
         }
         if ($this->isApiError($status_code)) {
             $this->httpRequest->close();
-            throw new MPApiException("Api error. Check response for details", $mp_response);
+            throw $this->buildApiException($status_code, $mp_response);
         }
 
         $this->httpRequest->close();
         return $mp_response;
     }
 
-    private function doExponentialBackoff(int $retry_count): void
+    private function buildApiException(int $status_code, MPResponse $response): MPApiException
     {
-        $exponential_backoff_time = pow(2, $retry_count);
-        $retry_delay_microseconds = $exponential_backoff_time * self::ONE_MILLISECOND * MercadoPagoConfig::getRetryDelay();
-        usleep($retry_delay_microseconds);
+        $msg = "Api error. Check response for details";
+        return match(true) {
+            $status_code === 400 => new MPBadRequestException($msg, $response),
+            $status_code === 401 => new MPAuthenticationException($msg, $response),
+            $status_code === 402 => new MPPaymentException($msg, $response),
+            $status_code === 403 => new MPForbiddenException($msg, $response),
+            $status_code === 404 => new MPNotFoundException($msg, $response),
+            $status_code === 409 => new MPIdempotencyException($msg, $response),
+            $status_code === 422 => new MPValidationException($msg, $response),
+            $status_code === 423 => new MPResourceLockedException($msg, $response),
+            $status_code === 424 => new MPDependencyException($msg, $response),
+            $status_code === 429 => new MPRateLimitException($msg, $response),
+            $status_code >= 500  => new MPServerException($msg, $response),
+            default              => new MPApiException($msg, $response),
+        };
+    }
+
+    private function computeDelayMicroseconds(int $attempt, int $initial_ms, int $max_ms, bool $use_jitter): int
+    {
+        $exponential = (int) ($initial_ms * pow(2, $attempt));
+        $capped = min($exponential, $max_ms);
+        if ($use_jitter && $capped > 0) {
+            $capped = random_int(0, $capped);
+        }
+        return $capped * self::ONE_MILLISECOND;
+    }
+
+    private function sleepMicroseconds(int $microseconds): void
+    {
+        if ($microseconds > 0) {
+            usleep($microseconds);
+        }
     }
 
     private function createHttpRequestOptions(MPRequest $request): array
@@ -121,18 +187,8 @@ class MPDefaultHttpClient implements MPHttpClient
         return $options;
     }
 
-    private function isServerError(int $status_code): bool
-    {
-        return $status_code >= 500;
-    }
-
     private function isApiError(int $status_code): bool
     {
         return $status_code < 200 || $status_code >= 300;
-    }
-
-    private function isLastRetry(int $retry_count): bool
-    {
-        return $retry_count >= MercadoPagoConfig::getMaxRetries();
     }
 }

--- a/src/MercadoPago/Net/MPRequest.php
+++ b/src/MercadoPago/Net/MPRequest.php
@@ -53,4 +53,31 @@ class MPRequest
     {
         return $this->connection_timeout;
     }
+
+    // --- Optional per-request retry config (set by MercadoPagoClient after construction) ---
+
+    private ?int $max_retries = null;
+    private ?array $retry_on = null;
+    private ?int $initial_delay_ms = null;
+    private ?int $max_delay_ms = null;
+    private ?bool $jitter = null;
+    private $on_retry = null;
+
+    public function getMaxRetries(): ?int { return $this->max_retries; }
+    public function setMaxRetries(?int $v): void { $this->max_retries = $v; }
+
+    public function getRetryOn(): ?array { return $this->retry_on; }
+    public function setRetryOn(?array $v): void { $this->retry_on = $v; }
+
+    public function getInitialDelayMs(): ?int { return $this->initial_delay_ms; }
+    public function setInitialDelayMs(?int $v): void { $this->initial_delay_ms = $v; }
+
+    public function getMaxDelayMs(): ?int { return $this->max_delay_ms; }
+    public function setMaxDelayMs(?int $v): void { $this->max_delay_ms = $v; }
+
+    public function getJitter(): ?bool { return $this->jitter; }
+    public function setJitter(?bool $v): void { $this->jitter = $v; }
+
+    public function getOnRetry() { return $this->on_retry; }
+    public function setOnRetry($v): void { $this->on_retry = $v; }
 }

--- a/tests/MercadoPago/Client/Unit/Ergonomia/TypedExceptionTest.php
+++ b/tests/MercadoPago/Client/Unit/Ergonomia/TypedExceptionTest.php
@@ -1,0 +1,239 @@
+<?php
+
+namespace MercadoPago\Tests\Client\Unit\Ergonomia;
+
+use MercadoPago\Client\Payment\PaymentClient;
+use MercadoPago\Client\Common\RequestOptions;
+use MercadoPago\Exceptions\MPApiException;
+use MercadoPago\Exceptions\MPAuthenticationException;
+use MercadoPago\Exceptions\MPBadRequestException;
+use MercadoPago\Exceptions\MPConnectionException;
+use MercadoPago\Exceptions\MPDependencyException;
+use MercadoPago\Exceptions\MPForbiddenException;
+use MercadoPago\Exceptions\MPIdempotencyException;
+use MercadoPago\Exceptions\MPNotFoundException;
+use MercadoPago\Exceptions\MPPaymentException;
+use MercadoPago\Exceptions\MPRateLimitException;
+use MercadoPago\Exceptions\MPResourceLockedException;
+use MercadoPago\Exceptions\MPServerException;
+use MercadoPago\Exceptions\MPValidationException;
+use MercadoPago\MercadoPagoConfig;
+use MercadoPago\Net\MPDefaultHttpClient;
+use MercadoPago\Net\MPResponse;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for typed exception hierarchy and retry config (TASK-007, TASK-009).
+ */
+final class TypedExceptionTest extends TestCase
+{
+    // ─── Exception subtype hierarchy ─────────────────────────────────────────
+
+    public function testAllSubtypesExtendMPApiException(): void
+    {
+        $response = new MPResponse(400, []);
+        $this->assertInstanceOf(MPApiException::class, new MPBadRequestException('', $response));
+        $this->assertInstanceOf(MPApiException::class, new MPAuthenticationException('', $response));
+        $this->assertInstanceOf(MPApiException::class, new MPPaymentException('', $response));
+        $this->assertInstanceOf(MPApiException::class, new MPForbiddenException('', $response));
+        $this->assertInstanceOf(MPApiException::class, new MPNotFoundException('', $response));
+        $this->assertInstanceOf(MPApiException::class, new MPIdempotencyException('', $response));
+        $this->assertInstanceOf(MPApiException::class, new MPValidationException('', $response));
+        $this->assertInstanceOf(MPApiException::class, new MPResourceLockedException('', $response));
+        $this->assertInstanceOf(MPApiException::class, new MPDependencyException('', $response));
+        $this->assertInstanceOf(MPApiException::class, new MPServerException('', $response));
+        $this->assertInstanceOf(MPApiException::class, new MPRateLimitException('', $response));
+    }
+
+    public function testMPRateLimitExceptionStoresRetryAfter(): void
+    {
+        $response = new MPResponse(429, []);
+        $ex = new MPRateLimitException('', $response, 45);
+        $this->assertSame(45, $ex->getRetryAfter());
+    }
+
+    public function testMPRateLimitExceptionNullRetryAfter(): void
+    {
+        $response = new MPResponse(429, []);
+        $ex = new MPRateLimitException('', $response);
+        $this->assertNull($ex->getRetryAfter());
+    }
+
+    public function testMPConnectionExceptionExtendsBaseException(): void
+    {
+        $ex = new MPConnectionException('network error');
+        $this->assertInstanceOf(\Exception::class, $ex);
+    }
+
+    // ─── Factory: status code → subtype mapping ───────────────────────────────
+
+    private function factoryExceptionForStatus(int $status_code): MPApiException
+    {
+        $mock = $this->getMockBuilder(\MercadoPago\Net\HttpRequest::class)->getMock();
+        $mock->method('execute')->willReturn('{}');
+        $mock->method('getInfo')->willReturn($status_code);
+
+        $http_client = new MPDefaultHttpClient($mock);
+        MercadoPagoConfig::setHttpClient($http_client);
+
+        $client = new PaymentClient();
+        try {
+            $client->get(1);
+            $this->fail("Expected MPApiException for status $status_code");
+        } catch (MPApiException $e) {
+            return $e;
+        }
+    }
+
+    public function testFactory400ReturnsMPBadRequestException(): void
+    {
+        $this->assertInstanceOf(MPBadRequestException::class, $this->factoryExceptionForStatus(400));
+    }
+
+    public function testFactory401ReturnsMPAuthenticationException(): void
+    {
+        $this->assertInstanceOf(MPAuthenticationException::class, $this->factoryExceptionForStatus(401));
+    }
+
+    public function testFactory402ReturnsMPPaymentException(): void
+    {
+        $this->assertInstanceOf(MPPaymentException::class, $this->factoryExceptionForStatus(402));
+    }
+
+    public function testFactory403ReturnsMPForbiddenException(): void
+    {
+        $this->assertInstanceOf(MPForbiddenException::class, $this->factoryExceptionForStatus(403));
+    }
+
+    public function testFactory404ReturnsMPNotFoundException(): void
+    {
+        $this->assertInstanceOf(MPNotFoundException::class, $this->factoryExceptionForStatus(404));
+    }
+
+    public function testFactory409ReturnsMPIdempotencyException(): void
+    {
+        $this->assertInstanceOf(MPIdempotencyException::class, $this->factoryExceptionForStatus(409));
+    }
+
+    public function testFactory422ReturnsMPValidationException(): void
+    {
+        $this->assertInstanceOf(MPValidationException::class, $this->factoryExceptionForStatus(422));
+    }
+
+    public function testFactory423ReturnsMPResourceLockedException(): void
+    {
+        $this->assertInstanceOf(MPResourceLockedException::class, $this->factoryExceptionForStatus(423));
+    }
+
+    public function testFactory424ReturnsMPDependencyException(): void
+    {
+        $this->assertInstanceOf(MPDependencyException::class, $this->factoryExceptionForStatus(424));
+    }
+
+    public function testFactory429ReturnsMPRateLimitException(): void
+    {
+        $this->assertInstanceOf(MPRateLimitException::class, $this->factoryExceptionForStatus(429));
+    }
+
+    public function testFactory500ReturnsMPServerException(): void
+    {
+        $this->assertInstanceOf(MPServerException::class, $this->factoryExceptionForStatus(500));
+    }
+
+    public function testFactoryUnknownClientErrorReturnsMPApiException(): void
+    {
+        $ex = $this->factoryExceptionForStatus(418);
+        $this->assertSame(MPApiException::class, get_class($ex));
+    }
+
+    public function testCatchByBaseTypeCatchesSubtype(): void
+    {
+        $response = new MPResponse(401, []);
+        $ex = new MPAuthenticationException('', $response);
+        $caught = false;
+        try {
+            throw $ex;
+        } catch (MPApiException $e) {
+            $caught = true;
+        }
+        $this->assertTrue($caught);
+    }
+
+    // ─── RequestOptions retry config ─────────────────────────────────────────
+
+    public function testDefaultConstantsExposed(): void
+    {
+        $this->assertSame(3, RequestOptions::DEFAULT_MAX_RETRIES);
+        $this->assertSame(60000, RequestOptions::DEFAULT_TIMEOUT_MS);
+        $this->assertSame(30000, RequestOptions::DEFAULT_MAX_DELAY_MS);
+        $this->assertSame([429, 500, 502, 503, 504], RequestOptions::DEFAULT_RETRY_ON);
+    }
+
+    public function testSetMaxRetriesNegativeThrowsInvalidArgument(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $opts = new RequestOptions();
+        $opts->setMaxRetries(-1);
+    }
+
+    public function testSetInitialDelayMsNegativeThrowsInvalidArgument(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $opts = new RequestOptions();
+        $opts->setInitialDelayMs(-100);
+    }
+
+    public function testSetMaxDelayMsNegativeThrowsInvalidArgument(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $opts = new RequestOptions();
+        $opts->setMaxDelayMs(-1);
+    }
+
+    public function testSetRetryOnInvalidCodeThrowsInvalidArgument(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $opts = new RequestOptions();
+        $opts->setRetryOn([999]);
+    }
+
+    public function testSetValidRetryOnAccepted(): void
+    {
+        $opts = new RequestOptions();
+        $opts->setRetryOn([429, 503]);
+        $this->assertSame([429, 503], $opts->getRetryOn());
+    }
+
+    public function testSetOnRetryCallback(): void
+    {
+        $opts = new RequestOptions();
+        $called = false;
+        $opts->setOnRetry(function (int $attempt, \Throwable $e) use (&$called) {
+            $called = true;
+        });
+        $this->assertNotNull($opts->getOnRetry());
+    }
+
+    // ─── Auto-pagination ─────────────────────────────────────────────────────
+
+    public function testPaymentClientHasSearchAllMethod(): void
+    {
+        $this->assertTrue(method_exists(PaymentClient::class, 'searchAll'));
+    }
+
+    public function testSearchAllReturnsGenerator(): void
+    {
+        $mock = $this->getMockBuilder(\MercadoPago\Net\HttpRequest::class)->getMock();
+        $json = file_get_contents(__DIR__ . '/../../../Resources/Mocks/Response/Payment/payment_search.json');
+        $mock->method('execute')->willReturn($json);
+        $mock->method('getInfo')->willReturn(200);
+
+        $http_client = new MPDefaultHttpClient($mock);
+        MercadoPagoConfig::setHttpClient($http_client);
+
+        $client = new PaymentClient();
+        $request = new \MercadoPago\Net\MPSearchRequest(5, 0);
+        $gen = $client->searchAll($request);
+        $this->assertInstanceOf(\Generator::class, $gen);
+    }
+}


### PR DESCRIPTION
## feat: typed exceptions, configurable retry, auto-pagination

### What changed

**Feature D — Typed exceptions**  
`MPApiException` now has 12 specific subtypes:

| HTTP | Exception |
|------|-----------|
| 400 | `MPBadRequestException` |
| 401 | `MPAuthenticationException` |
| 402 | `MPPaymentException` *(new — AP/Orders)* |
| 403 | `MPForbiddenException` |
| 404 | `MPNotFoundException` |
| 409 | `MPIdempotencyException` |
| 422 | `MPValidationException` *(new)* |
| 423 | `MPResourceLockedException` *(new, retryable)* |
| 424 | `MPDependencyException` *(new, retryable)* |
| 429 | `MPRateLimitException` — exposes `getRetryAfter()` (seconds) |
| 5xx | `MPServerException` |
| network | `MPConnectionException` |

All subtypes extend `MPApiException`. `MPDefaultHttpClient::makeRequest()` uses a PHP 8 `match` expression factory to select the right type. Security: errors are built from the API response body — the `Authorization` header (sent in the request, not the response) is never captured.

**Feature B — Retry + Timeout**  
`RequestOptions` gains optional retry fields with getters/setters and validation (`\InvalidArgumentException` on invalid values):
- `max_retries`, `retry_on`, `initial_delay_ms`, `max_delay_ms`
- `jitter` — uses `random_int()` (cryptographically secure in PHP 7+)
- `on_retry` — `callable(int $attempt, \Throwable $error): void`

Constants: `RequestOptions::DEFAULT_MAX_RETRIES`, `DEFAULT_TIMEOUT_MS`, `DEFAULT_MAX_DELAY_MS`, `DEFAULT_RETRY_ON`.

Retry config propagates via `MPRequest` so `MPDefaultHttpClient::send()` respects per-request overrides.

**Feature A — Auto-pagination**  
`MPAutoPaginationGenerator::of()` returns a PHP `Generator` (uses `yield`). `searchAll()` added to:
- `PaymentClient`
- `CustomerClient`
- `PreApprovalClient`

```php
foreach ($client->searchAll($request) as $payment) {
    process($payment); // pages fetched lazily
}