### PR TITLE
Fix webhook toleranceSeconds unit mismatch

### DIFF
--- a/src/MercadoPago/Webhook/WebhookSignatureValidator.php
+++ b/src/MercadoPago/Webhook/WebhookSignatureValidator.php
@@ -73,7 +73,7 @@ final class WebhookSignatureValidator
         $xRequestId = self::normalize($xRequestId);
         $dataId = self::normalize($dataId);
         $versions = $supportedVersions ?: self::DEFAULT_SUPPORTED_VERSIONS;
-        $now = $nowProvider ?? static fn (): int => (int) (microtime(true) * 1000);
+        $now = $nowProvider ?? static fn(): int => (int) (microtime(true) * 1000);
 
         if ($xSignature === null) {
             throw new InvalidWebhookSignatureException(
@@ -134,7 +134,8 @@ final class WebhookSignatureValidator
         }
 
         if ($toleranceSeconds !== null) {
-            $driftMs = abs($now() - (int) $ts);
+            $tsMs = (int) $ts * 1000;
+            $driftMs = abs($now() - $tsMs);
             if ($driftMs > $toleranceSeconds * 1000) {
                 throw new InvalidWebhookSignatureException(
                     SignatureFailureReason::TIMESTAMP_OUT_OF_TOLERANCE,

--- a/tests/MercadoPago/Webhook/Unit/WebhookSignatureValidatorUnitTest.php
+++ b/tests/MercadoPago/Webhook/Unit/WebhookSignatureValidatorUnitTest.php
@@ -151,6 +151,20 @@ final class WebhookSignatureValidatorUnitTest extends TestCase
         $this->assertTrue(true);
     }
 
+    public function testWithinTolerancePassesWithSecondsPrecisionTimestamp(): void
+    {
+        $tsSeconds = (string) time();
+        $h = self::computeHash(self::DATA_ID_LOWER, self::REQUEST_ID, $tsSeconds, self::SECRET);
+        WebhookSignatureValidator::validate(
+            self::buildHeader($h, $tsSeconds),
+            self::REQUEST_ID,
+            self::DATA_ID_LOWER,
+            self::SECRET,
+            3600
+        );
+        $this->assertTrue(true);
+    }
+
     // case 9
     public function testDataIdAbsentExcludesIdPair(): void
     {


### PR DESCRIPTION
Fixes #458: ts header value is in seconds, now() returns ms. Multiplying ts by 1000 before comparing. All 82 tests pass.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)