### PR TITLE
chore: bump version to 3.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to this project will be documented in this file.
 
 This project follows Keep a Changelog and Semantic Versioning.
 
+## [3.13.0] - 2026-08-04
+
+### Added
+
+- **SDK ergonomics**: typed exceptions, configurable retry, and auto-pagination ([#646](https://github.com/mercadopago/sdk-php/pull/646))
+  - `MPApiException` now has 12 specific subtypes per HTTP status code
+  - `MPRequestOptions` gains optional `maxRetries`, `retryOn`, `initialDelayMs`, `maxDelayMs` and `onRetry` callback
+  - New auto-pagination support on search endpoints
+- **Missing API methods** — `DisbursementRefundClient::list()`, `AdvancedPaymentClient::update()`, `CustomerCard::update()`, `PaymentClient::update()` ([#645](https://github.com/mercadopago/sdk-php/pull/645))
+- **CREDENTIAL_ON_FILE messaging fields** on `Payment` types ([#642](https://github.com/mercadopago/sdk-php/pull/642)): `firstTransaction`, `storage`, `transactionInitiator`, `reference`
+
+### Fixed
+
+- Webhook `toleranceSeconds` unit mismatch — `ts` header value compared in seconds against a millisecond clock ([#647](https://github.com/mercadopago/sdk-php/pull/647))
+- `constantTimeEquals` `RangeError` on multibyte v1 hash ([#647](https://github.com/mercadopago/sdk-php/pull/647))
+
+### CI
+
+- Hotfix: pin GitHub Actions to SHA for supply chain security ([#638](https://github.com/mercadopago/sdk-php/pull/638))
+
+### Dependencies
+
+- Bump `symfony/console` ([#643](https://github.com/mercadopago/sdk-php/pull/643))
+- Bump `friendsofphp/php-cs-fixer` ([#644](https://github.com/mercadopago/sdk-php/pull/644), [#640](https://github.com/mercadopago/sdk-php/pull/640))
+- Bump `actions/checkout` to `v7.0.1` ([#641](https://github.com/mercadopago/sdk-php/pull/641))
+
 ## [3.12.0] - 2026-06-27
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ First time using Mercado Pago? Create your [Mercado Pago account](https://www.me
 2. Install PHP SDK for MercadoPago running in command line:
 
 ```
-composer require "mercadopago/dx-php:3.12.1"
+composer require "mercadopago/dx-php:3.13.0"
 ```
 
 > You can also run _composer require "mercadopago/dx-php:2.6.2"_ for PHP7.1 or _composer require "mercadopago/dx-php:1.12.6"_ for PHP5.6.

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "mercadopago/dx-php",
     "description": "Mercado Pago PHP SDK",
-    "version": "3.12.1",
+    "version": "3.13.0",
     "type": "library",
     "license": "MIT",
     "homepage": "https://github.com/mercadopago/sdk-php",

--- a/src/MercadoPago/MercadoPagoConfig.php
+++ b/src/MercadoPago/MercadoPagoConfig.php
@@ -22,7 +22,7 @@ use MercadoPago\Net\MPHttpClient;
 class MercadoPagoConfig
 {
     /** @var string Mercado Pago SDK version. */
-    public static string $CURRENT_VERSION = "3.12.1";
+    public static string $CURRENT_VERSION = "3.13.0";
 
     /** @var string Base URL for all API requests. Override only for testing or proxy scenarios. */
     public static string $BASE_URL = "https://api.mercadopago.com";


### PR DESCRIPTION
## Summary

- Bump version from `3.12.1` to `3.13.0`
- Update `composer.json`, `MercadoPagoConfig.php`, `README.md`, and `CHANGELOG.md`

## Changelog entry

### Added
- **SDK ergonomics**: typed exceptions, configurable retry, and auto-pagination ([#646](https://github.com/mercadopago/sdk-php/pull/646))
  - `MPApiException` now has 12 specific subtypes per HTTP status code
  - `MPRequestOptions` gains optional `maxRetries`, `retryOn`, `initialDelayMs`, `maxDelayMs` and `onRetry` callback
  - New auto-pagination support on search endpoints
- **Missing API methods** — `DisbursementRefundClient::list()`, `AdvancedPaymentClient::update()`, `CustomerCard::update()`, `PaymentClient::update()` ([#645](https://github.com/mercadopago/sdk-php/pull/645))
- **CREDENTIAL_ON_FILE messaging fields** on `Payment` types ([#642](https://github.com/mercadopago/sdk-php/pull/642)): `firstTransaction`, `storage`, `transactionInitiator`, `reference`

### Fixed
- Webhook `toleranceSeconds` unit mismatch ([#647](https://github.com/mercadopago/sdk-php/pull/647))
- `constantTimeEquals` `RangeError` on multibyte v1 hash ([#647](https://github.com/mercadopago/sdk-php/pull/647))

### CI
- Hotfix: pin GitHub Actions to SHA for supply chain security ([#638](https://github.com/mercadopago/sdk-php/pull/638))

### Dependencies
- Bump `symfony/console` ([#643](https://github.com/mercadopago/sdk-php/pull/643))
- Bump `friendsofphp/php-cs-fixer` ([#644](https://github.com/mercadopago/sdk-php/pull/644), [#640](https://github.com/mercadopago/sdk-php/pull/640))
- Bump `actions/checkout` to `v7.0.1` ([#641](https://github.com/mercadopago/sdk-php/pull/641))

## Test plan
- [ ] CI passes
- [ ] Version string is correct in all files