### PR TITLE
chore: bump version to 3.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 This project follows Keep a Changelog and Semantic Versioning.
 
+## [3.14.0] - 2026-08-11
+
+### Added
+- **Automatic Payments example**: two-step recurring flow ([#639](https://github.com/mercadopago/sdk-php/pull/639))
+- **Order typed Request classes** with dual acceptance in `create()` ([#639](https://github.com/mercadopago/sdk-php/pull/639))
+- **Order request layer**: reuse `Common\Address`, `Identification`, `Phone` ([#639](https://github.com/mercadopago/sdk-php/pull/639))
+- **Pagination**: support `data` key (Orders v2) and string paging totals in `MPAutoPaginationGenerator` ([#639](https://github.com/mercadopago/sdk-php/pull/639))
+
+### Fixed
+- **Stored credential**: rename `prev_transaction_ref` to `previous_transaction_reference` ([#639](https://github.com/mercadopago/sdk-php/pull/639))
+
+### CI
+- Add CD workflow ([#651](https://github.com/mercadopago/sdk-php/pull/651))
+- Standardize CI workflow ([#651](https://github.com/mercadopago/sdk-php/pull/651))
+- Add mock-based unit test coverage ([#651](https://github.com/mercadopago/sdk-php/pull/651))
+
+### Dependencies
+- Fix CVE-2026-67434: upgrade `squizlabs/php_codesniffer` to `4.0.4` ([#651](https://github.com/mercadopago/sdk-php/pull/651))
+
 ## [3.13.0] - 2026-08-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ First time using Mercado Pago? Create your [Mercado Pago account](https://www.me
 2. Install PHP SDK for MercadoPago running in command line:
 
 ```
-composer require "mercadopago/dx-php:3.13.0"
+composer require "mercadopago/dx-php:3.14.0"
 ```
 
 > You can also run _composer require "mercadopago/dx-php:2.6.2"_ for PHP7.1 or _composer require "mercadopago/dx-php:1.12.6"_ for PHP5.6.

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "mercadopago/dx-php",
     "description": "Mercado Pago PHP SDK",
-    "version": "3.13.0",
+    "version": "3.14.0",
     "type": "library",
     "license": "MIT",
     "homepage": "https://github.com/mercadopago/sdk-php",

--- a/src/MercadoPago/MercadoPagoConfig.php
+++ b/src/MercadoPago/MercadoPagoConfig.php
@@ -22,7 +22,7 @@ use MercadoPago\Net\MPHttpClient;
 class MercadoPagoConfig
 {
     /** @var string Mercado Pago SDK version. */
-    public static string $CURRENT_VERSION = "3.13.0";
+    public static string $CURRENT_VERSION = "3.14.0";
 
     /** @var string Base URL for all API requests. Override only for testing or proxy scenarios. */
     public static string $BASE_URL = "https://api.mercadopago.com";


### PR DESCRIPTION
## Summary
- Bump version from \`3.13.0\` to \`3.14.0\`
- Update \`composer.json\`, \`MercadoPagoConfig.php\`, \`README.md\`, \`CHANGELOG.md\`

## Changelog entry
### Added
- Automatic Payments example: two-step recurring flow ([#639](https://github.com/mercadopago/sdk-php/pull/639))
- Order typed Request classes with dual acceptance in \`create()\` ([#639](https://github.com/mercadopago/sdk-php/pull/639))
- Order request layer: reuse \`Common\Address\`, \`Identification\`, \`Phone\` ([#639](https://github.com/mercadopago/sdk-php/pull/639))
- Pagination: support \`data\` key (Orders v2) and string paging totals in \`MPAutoPaginationGenerator\` ([#639](https://github.com/mercadopago/sdk-php/pull/639))
### Fixed
- Stored credential: rename \`prev_transaction_ref\` to \`previous_transaction_reference\` ([#639](https://github.com/mercadopago/sdk-php/pull/639))
### CI
- Add CD workflow ([#651](https://github.com/mercadopago/sdk-php/pull/651))
- Standardize CI workflow and add mock-based unit test coverage ([#651](https://github.com/mercadopago/sdk-php/pull/651))
### Dependencies
- Fix CVE-2026-67434: upgrade \`squizlabs/php_codesniffer\` to \`4.0.4\` ([#651](https://github.com/mercadopago/sdk-php/pull/651))

## Test plan
- [ ] CI passes
- [ ] Version string is correct in all files