### PR TITLE
feat: add COF network data support + bump version to 3.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 This project follows Keep a Changelog and Semantic Versioning.
 
+## [3.15.0] - 2026-08-25
+
+### Added
+- **COF network data support**: new fields on `NetworkData` and `PointOfInteraction` payment resources
+
 ## [3.14.0] - 2026-08-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ First time using Mercado Pago? Create your [Mercado Pago account](https://www.me
 2. Install PHP SDK for MercadoPago running in command line:
 
 ```
-composer require "mercadopago/dx-php:3.14.0"
+composer require "mercadopago/dx-php:3.15.0"
 ```
 
 > You can also run _composer require "mercadopago/dx-php:2.6.2"_ for PHP7.1 or _composer require "mercadopago/dx-php:1.12.6"_ for PHP5.6.

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "mercadopago/dx-php",
     "description": "Mercado Pago PHP SDK",
-    "version": "3.14.0",
+    "version": "3.15.0",
     "type": "library",
     "license": "MIT",
     "homepage": "https://github.com/mercadopago/sdk-php",

--- a/src/MercadoPago/MercadoPagoConfig.php
+++ b/src/MercadoPago/MercadoPagoConfig.php
@@ -22,7 +22,7 @@ use MercadoPago\Net\MPHttpClient;
 class MercadoPagoConfig
 {
     /** @var string Mercado Pago SDK version. */
-    public static string $CURRENT_VERSION = "3.14.0";
+    public static string $CURRENT_VERSION = "3.15.0";
 
     /** @var string Base URL for all API requests. Override only for testing or proxy scenarios. */
     public static string $BASE_URL = "https://api.mercadopago.com";

--- a/src/MercadoPago/Resources/Payment/NetworkData.php
+++ b/src/MercadoPago/Resources/Payment/NetworkData.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace MercadoPago\Resources\Payment;
+
+class NetworkData
+{
+    public ?string $network_transaction_id;
+    public ?string $transaction_link_id;
+}

--- a/src/MercadoPago/Resources/Payment/PointOfInteraction.php
+++ b/src/MercadoPago/Resources/Payment/PointOfInteraction.php
@@ -27,9 +27,13 @@ class PointOfInteraction
     /** @var TransactionData|array|null Transaction data generated at the point of interaction (e.g. QR content, ticket URL). */
     public array|object|null $transaction_data;
 
+    /** @var NetworkData|array|null Card-network identifiers for a COF payment. */
+    public array|object|null $network_data;
+
     private $map = [
         "application_data" => "MercadoPago\Resources\Payment\ApplicationData",
         "transaction_data" => "MercadoPago\Resources\Payment\TransactionData",
+        "network_data" => "MercadoPago\Resources\Payment\NetworkData",
     ];
 
     /**


### PR DESCRIPTION
## Summary
- Add COF network data support: new fields on \`NetworkData\` and \`PointOfInteraction\` payment resources
- Bump version from \`3.14.0\` to \`3.15.0\`
- Update \`composer.json\`, \`MercadoPagoConfig.php\`, \`README.md\`, \`CHANGELOG.md\`

## Test plan
- [ ] CI passes
- [ ] Version string is correct in all files