### PR TITLE
feat: support legacy COF network transaction id

### DIFF
--- a/src/MercadoPago/Resources/Payment/TransactionData.php
+++ b/src/MercadoPago/Resources/Payment/TransactionData.php
@@ -39,6 +39,9 @@ class TransactionData
     /** End-to-end identifier for Pix transactions, used for reconciliation. */
     public ?string $e2e_id;
 
+    /** Legacy card-network transaction identifier within transaction data. */
+    public ?string $network_transaction_id;
+
     /** Indicates whether this is the first transaction in a CREDENTIAL_ON_FILE agreement. */
     public ?bool $first_transaction;
 


### PR DESCRIPTION
## Summary
- Add support for legacy COF network transaction id on `TransactionData` payment resource
- Follow-up to #656 (COF network data support), which already merged into master

## Test plan
- [ ] CI passes