### PR TITLE
chore: bump version to 3.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 This project follows Keep a Changelog and Semantic Versioning.
 
+## [3.16.0] - 2026-08-27
+
+### Added
+- **Credential-on-file and automatic payments**: support nested `network_data`, expanded gateway network data, and `automatic_payments.subscription`.
+
 ## [3.15.0] - 2026-08-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ First time using Mercado Pago? Create your [Mercado Pago account](https://www.me
 2. Install PHP SDK for MercadoPago running in command line:
 
 ```
-composer require "mercadopago/dx-php:3.15.0"
+composer require "mercadopago/dx-php:3.16.0"
 ```
 
 > You can also run _composer require "mercadopago/dx-php:2.6.2"_ for PHP7.1 or _composer require "mercadopago/dx-php:1.12.6"_ for PHP5.6.

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "mercadopago/dx-php",
     "description": "Mercado Pago PHP SDK",
-    "version": "3.15.0",
+    "version": "3.16.0",
     "type": "library",
     "license": "MIT",
     "homepage": "https://github.com/mercadopago/sdk-php",

--- a/src/MercadoPago/MercadoPagoConfig.php
+++ b/src/MercadoPago/MercadoPagoConfig.php
@@ -22,7 +22,7 @@ use MercadoPago\Net\MPHttpClient;
 class MercadoPagoConfig
 {
     /** @var string Mercado Pago SDK version. */
-    public static string $CURRENT_VERSION = "3.15.0";
+    public static string $CURRENT_VERSION = "3.16.0";
 
     /** @var string Base URL for all API requests. Override only for testing or proxy scenarios. */
     public static string $BASE_URL = "https://api.mercadopago.com";


### PR DESCRIPTION
## Summary

Bumps the PHP SDK release version to 3.16.0 after the latest merged backwards-compatible functionality.

## Files updated

- composer.json
- src/MercadoPago/MercadoPagoConfig.php
- README.md
- CHANGELOG.md

## Validation

- Confirmed version metadata and changelog consistency.
- No runtime code changes.